### PR TITLE
relaxed int conditions on subdomain_id

### DIFF
--- a/ufl/algorithms/domain_analysis.py
+++ b/ufl/algorithms/domain_analysis.py
@@ -28,6 +28,7 @@ from ufl.integral import Integral
 from ufl.form import Form
 from ufl.sorting import cmp_expr, sorted_expr
 from ufl.utils.sorting import canonicalize_metadata, sorted_by_key, sorted_by_tuple_key
+import numpy as np
 
 
 class IntegralData(object):
@@ -143,10 +144,10 @@ def group_integrals_by_domain_and_type(integrals, domains):
 def integral_subdomain_ids(integral):
     "Get a tuple of integer subdomains or a valid string subdomain from integral."
     did = integral.subdomain_id()
-    if isinstance(did, int):
+    if isinstance(did, (int, np.integer)):
         return (did,)
     elif isinstance(did, tuple):
-        ufl_assert(all(isinstance(d, int) for d in did),
+        ufl_assert(all(isinstance(d, (int, np.integer)) for d in did),
                    "Expecting only integer subdomains in tuple.")
         return did
     elif did in ("everywhere", "otherwise"):

--- a/ufl/measure.py
+++ b/ufl/measure.py
@@ -29,6 +29,7 @@ from ufl.constantvalue import as_ufl
 from ufl.utils.dicts import EmptyDict
 from ufl.domain import as_domain, AbstractDomain, extract_domains
 from ufl.protocols import id_or_none, metadata_equal, metadata_hashdata
+import numpy as np
 
 
 # Export list for ufl.classes
@@ -163,9 +164,9 @@ class Measure(object):
         # Accept "everywhere", single subdomain, or multiple
         # subdomains
         ufl_assert(subdomain_id in ("everywhere",) or
-                   isinstance(subdomain_id, int) or
+                   isinstance(subdomain_id, (int, np.integer)) or
                    (isinstance(subdomain_id, tuple) and
-                    all(isinstance(did, int) for did in subdomain_id)),
+                    all(isinstance(did, (int, np.integer)) for did in subdomain_id)),
                    "Invalid subdomain_id.")
         self._subdomain_id = subdomain_id
 
@@ -412,7 +413,7 @@ a single integral.
 
         # Check that we have an integer subdomain or a string
         # ("everywhere" or "otherwise", any more?)
-        ufl_assert(isinstance(subdomain_id, (int, str)),
+        ufl_assert(isinstance(subdomain_id, (int, str, np.integer)),
                    "Expecting integer or string domain id.")
 
         # If we don't have an integration domain, try to find one in


### PR DESCRIPTION
Allow `numpy.integer` types to be accepted as well as `str` and `int` in `subdomain_id`