### PR TITLE
Mimetic spectral elements

### DIFF
--- a/test/test_elements.py
+++ b/test/test_elements.py
@@ -199,3 +199,25 @@ def test_radau():
 
         element = FiniteElement("Radau", cell, degree)
         assert element == eval(repr(element))
+
+
+def test_mse():
+    for degree in (2, 3, 4, 5):
+        element = FiniteElement('EGL', interval, degree)
+        assert element == eval(repr(element))
+
+        element = FiniteElement('EGL-Edge', interval, degree - 1)
+        assert element == eval(repr(element))
+
+        element = FiniteElement('EGL-Edge L2', interval, degree - 1)
+        assert element == eval(repr(element))
+
+    for degree in (1, 2, 3, 4, 5):
+        element = FiniteElement('GLL', interval, degree)
+        assert element == eval(repr(element))
+
+        element = FiniteElement('GLL-Edge', interval, degree - 1)
+        assert element == eval(repr(element))
+
+        element = FiniteElement('GLL-Edge L2', interval, degree - 1)
+        assert element == eval(repr(element))

--- a/ufl/finiteelement/elementlist.py
+++ b/ufl/finiteelement/elementlist.py
@@ -258,6 +258,20 @@ register_alias("P- L2", lambda family, dim, order,
 register_alias("Q- L2", lambda family, dim, order,
                degree: feec_element_l2(family, dim, order, degree))
 
+# mimetic spectral elements - primal and dual complexs
+register_element("Extended-Gauss-Legendre", "EGL", 0, H1, "identity", (2, None),
+                 ("interval",))
+register_element("Extended-Gauss-Legendre Edge", "EGL-Edge", 0, L2, "identity", (1, None),
+                 ("interval",))
+register_element("Extended-Gauss-Legendre Edge L2", "EGL-Edge L2", 0, L2, "L2 Piola", (1, None),
+                 ("interval",))
+register_element("Gauss-Lobatto-Legendre Edge", "GLL-Edge", 0, L2, "identity", (0, None),
+                 ("interval",))
+register_element("Gauss-Lobatto-Legendre Edge L2", "GLL-Edge L2", 0, L2, "L2 Piola", (0, None),
+                 ("interval",))
+
+
+# NOTE- the edge elements for primal mimetic spectral elements are accessed by using variant='mse' in the appropriate places
 
 def feec_element(family, n, r, k):
     """Finite element exterior calculus notation


### PR DESCRIPTION
This pull request adds mimetic spectral elements (described at https://www.sciencedirect.com/science/article/pii/S0021999113006414 and https://arxiv.org/abs/1111.4304), both the primal and dual complexes. This is done by adding the relevant 1D H1 element for the dual complex: Extended Gauss Legendre (EGL); and the L2 edge elements associated with GLL and EGL. These are non-Ciarlet finite elements that use a basis that histopolates (http://people.math.sfu.ca/~nrobidou/public_html/prints/histogram/histogram.pdf) rather than interpolates. The nD deRham complex on hypercubes is then accessible using the variant keyword (either “mse” or “dualmse”) with the relevant elements (DQ, Q, RTCF, etc.).

It also requires correct (integral-preserving) L2 pullbacks from https://github.com/FEniCS/ufl/pull/4.