### PR TITLE
Replace hand-coded stack in traversal with growable one

### DIFF
--- a/ufl/core/compute_expr_hash.py
+++ b/ufl/core/compute_expr_hash.py
@@ -2,7 +2,7 @@
 """Non-recursive traversal-based hash computation algorithm.
 
 Fast iteration over nodes in an ``Expr`` DAG to compute
-memorized hashes for all unique nodes.
+memoized hashes for all unique nodes.
 """
 
 # Copyright (C) 2015 Martin Sandve Alnæs
@@ -13,38 +13,23 @@ memorized hashes for all unique nodes.
 #
 # Modified by Massimiliano Leoni, 2016
 
-# This limits the _depth_ of expression trees
-_recursion_limit_ = 6400  # should be enough for everyone
-
 
 def compute_expr_hash(expr):
     """Compute hashes of *expr* and all its nodes efficiently, without using Python recursion."""
     if expr._hash is not None:
         return expr._hash
-
-    stack = [None] * _recursion_limit_
-    stacksize = 0
-
-    ops = expr.ufl_operands
-    stack[stacksize] = [expr, ops, len(ops)]
-    stacksize += 1
-
-    while stacksize > 0:
-        entry = stack[stacksize - 1]
-        e = entry[0]
-        if e._hash is not None:
-            # cutoff: don't need to visit children when hash has previously been computed
-            stacksize -= 1
-        elif entry[2] == 0:
-            # all children consumed: trigger memoized hash computation
-            e._hash = e._ufl_compute_hash_()
-            stacksize -= 1
+    # Postorder traversal, can't use unique_post_traversal, since that
+    # uses a set which requires that this hash is computed.
+    lifo = [(expr, list(expr.ufl_operands))]
+    while lifo:
+        expr, deps = lifo[-1]
+        for i, dep in enumerate(deps):
+            if dep is not None and dep._hash is None:
+                lifo.append((dep, list(dep.ufl_operands)))
+                deps[i] = None
+                break
         else:
-            # add children to stack to hash them first
-            entry[2] -= 1
-            o = entry[1][entry[2]]
-            oops = o.ufl_operands
-            stack[stacksize] = [o, oops, len(oops)]
-            stacksize += 1
-
+            if expr._hash is None:
+                expr._hash = expr._ufl_compute_hash_()
+            lifo.pop()
     return expr._hash


### PR DESCRIPTION
Significantly speeds up traversal for big trees.

As a slightly pathological case, but distilled from an issue that @jrmaddison observed in tlm_adjoint:

```python
#!/usr/bin/env python3

import time
import ufl

N = 5000

element = ufl.classes.FiniteElement(family="R", degree=0)
space = ufl.classes.FunctionSpace(None, element)

coeffs = [ufl.classes.Coefficient(space) for n in range(N)]
replacement_coeffs = [ufl.classes.Coefficient(space) for n in range(N)]
replace_map = dict(zip(coeffs, replacement_coeffs))

t0 = time.time()
for i in range(50):
    e = ufl.classes.Zero()
    for c in coeffs:
        e += c
print(f"construction time = {time.time() - t0:.3f} s")

t0 = time.time()
for i in range(50):
    ufl.replace(e, replace_map)
print(f"ufl.replace time = {time.time() - t0:.3f} s")
```

Before (master):

```
$ python ufl-time.py
construction time = 1.121 s
ufl.replace time = 8.496 s
```

After:
```
$ python ufl-time.py
construction time = 1.114 s
ufl.replace time = 4.568 s
```

This does not, as far as I can tell, change any signature computation or traversal order. I have not tested with dolfin though.