### PR TITLE
Transformed form arguments

### DIFF
--- a/doc/sphinx/source/manual/examples.rst
+++ b/doc/sphinx/source/manual/examples.rst
@@ -380,6 +380,53 @@ This example is implemented in the file ``PoissonDG.ufl`` in
 the collection of demonstration forms included with the UFL source
 distribution.
 
+Poisson equation with Dirichlet boundary conditions
+===================================================
+
+The bilinear and linear forms for Poisson's equation with Dirichlet
+boundary condition,
+
+.. math::
+
+   \int_{\partial\Omega} u \mathop{dx} &= \int_{\partial\Omega} g \mathop{dx},
+
+is implemented in the following. As before, we have::
+
+  element = FiniteElement("Lagrange", triangle, 1)
+
+  v = TestFunction(element)
+  u = TrialFunction(element)
+  f = Coefficient(element)
+
+Here, we also define a coefficient for the Dirichlet boundary value as::
+
+  g = Coefficient(element)
+
+We then mark degrees of freedom for which we implement the
+domain equation::
+
+  transform_op_0 = TopologicalCoefficient(element)
+
+and those on which the Dirichlet condition is enforced::
+
+  transform_op_1 = TopologicalCoefficient(element)
+
+We then project :math:`v`, :math:`u`, and :math:`g` to
+appropriate subspaces as::
+
+  v0 = Transformed(v, transform_op_0)
+  v1 = Transformed(v, transform_op_1)
+  u0 = Transformed(u, transform_op_0)
+  u1 = Transformed(u, transform_op_1)
+  g1 = Transformed(g, transform_op_1)
+
+The Poisson equation with Dirichlet boundary condition is
+then implemented as::
+
+  a = dot(grad(u0), grad(v0)) * dx + u1 * v1 * ds
+  L = f * v0 * dx - dot(grad(g1), grad(v0)) * dx + g * v1 * ds
+
+Note that the bilinear form :math:`a` is symmetrized.
 
 The Quadrature family
 =====================

--- a/test/test_transformed.py
+++ b/test/test_transformed.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env py.test
+# -*- coding: utf-8 -*-
+
+"""
+Test use of transformed.
+"""
+
+import pytest
+from ufl import *
+from ufl.algorithms import compute_form_data
+
+
+def test_transformed_one_form():
+    cell = triangle
+    element = VectorElement("Lagrange", cell, 1)
+
+    # Mesh with some underlying coordinates.
+    domain = Mesh(cell)
+    # Regular function space on the fixed mesh.
+    V = FunctionSpace(domain, element)
+
+    # Topological mesh with no underlying coordinates.
+    t_domain = TopologicalMesh(cell)
+    # Topological function space on the topological mesh.
+    t_V = TopologicalFunctionSpace(t_domain, element)
+
+    c = Coefficient(V)
+    # TestFunction defined on the full space V.
+    v = TestFunction(V)
+    # TestFunction restricted onto subspace V0 of V,
+    # which, for instance, represents V modified to
+    # apply Dirichlet boundary conditions strongly.
+    # Given representation of V on which v is defined,
+    # this restriction can be encoded in a topological
+    # coefficient defined on the associated topological
+    # function space t_V.
+    transform_op = TopologicalCoefficient(t_V)
+    v0 = Transformed(v, transform_op)
+
+    # Some form for testing.
+    form = inner(c, grad(v0[1])) * dx
+
+    fd = compute_form_data(
+        form,
+        do_apply_function_pullbacks=True,
+        do_apply_integral_scaling=True,
+        do_apply_geometry_lowering=True,
+        preserve_geometry_types=(),
+        do_apply_restrictions=True,
+        do_apply_transforms=True,
+        do_estimate_degrees=True,
+        complex_mode=True
+    )
+
+    assert fd.num_topological_coefficients == 1
+    assert fd.reduced_topological_coefficients[0] is transform_op
+    assert fd.original_topological_coefficient_positions == [0, ]
+    assert fd.integral_data[0].integral_topological_coefficients == set((transform_op, ))
+    assert fd.integral_data[0].enabled_topological_coefficients == [True, ]

--- a/ufl/__init__.py
+++ b/ufl/__init__.py
@@ -107,6 +107,7 @@ A very brief overview of the language contents follows:
     - Constant
     - VectorConstant
     - TensorConstant
+    - TopologicalCoefficient
 
 * Splitting form arguments in mixed spaces::
 
@@ -292,7 +293,7 @@ from ufl.argument import Argument, TestFunction, TrialFunction, \
     Arguments, TestFunctions, TrialFunctions
 
 # Coefficients
-from ufl.coefficient import Coefficient, Coefficients
+from ufl.coefficient import Coefficient, Coefficients, TopologicalCoefficient
 from ufl.constant import Constant, VectorConstant, TensorConstant
 
 # Split function
@@ -385,7 +386,7 @@ __all__ = [
     'FunctionSpace', 'MixedFunctionSpace', 'TopologicalFunctionSpace',
     'Argument', 'TestFunction', 'TrialFunction',
     'Arguments', 'TestFunctions', 'TrialFunctions',
-    'Coefficient', 'Coefficients',
+    'Coefficient', 'Coefficients', 'TopologicalCoefficient',
     'Constant', 'VectorConstant', 'TensorConstant',
     'split',
     'PermutationSymbol', 'Identity', 'zero', 'as_ufl',

--- a/ufl/__init__.py
+++ b/ufl/__init__.py
@@ -90,6 +90,7 @@ A very brief overview of the language contents follows:
 
     - FunctionSpace
     - MixedFunctionSpace
+    - TopologicalFunctionSpace
 
 * Arguments::
 
@@ -284,7 +285,7 @@ from ufl.finiteelement import FiniteElementBase, FiniteElement, \
 from ufl.finiteelement.elementlist import register_element, show_elements  # , ufl_elements
 
 # Function spaces
-from ufl.functionspace import FunctionSpace, MixedFunctionSpace
+from ufl.functionspace import FunctionSpace, MixedFunctionSpace, TopologicalFunctionSpace
 
 # Arguments
 from ufl.argument import Argument, TestFunction, TrialFunction, \
@@ -381,7 +382,7 @@ __all__ = [
     'HDivElement', 'HCurlElement',
     'BrokenElement', 'FacetElement', 'InteriorElement',
     'register_element', 'show_elements',
-    'FunctionSpace', 'MixedFunctionSpace',
+    'FunctionSpace', 'MixedFunctionSpace', 'TopologicalFunctionSpace',
     'Argument', 'TestFunction', 'TrialFunction',
     'Arguments', 'TestFunctions', 'TrialFunctions',
     'Coefficient', 'Coefficients',

--- a/ufl/__init__.py
+++ b/ufl/__init__.py
@@ -60,6 +60,7 @@ A very brief overview of the language contents follows:
     - Mesh
     - MeshView
     - TensorProductMesh
+    - TopologicalMesh
 
 * Sobolev spaces::
 
@@ -260,7 +261,7 @@ from ufl.log import get_handler, get_logger, set_handler, set_level, add_logfile
 # Types for geometric quantities
 
 from ufl.cell import as_cell, AbstractCell, Cell, TensorProductCell
-from ufl.domain import as_domain, AbstractDomain, Mesh, MeshView, TensorProductMesh
+from ufl.domain import as_domain, AbstractDomain, Mesh, MeshView, TensorProductMesh, TopologicalMesh
 from ufl.geometry import (
     SpatialCoordinate,
     FacetNormal, CellNormal,
@@ -366,7 +367,7 @@ __all__ = [
     'get_handler', 'get_logger', 'set_handler', 'set_level', 'add_logfile',
     'UFLException', 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL',
     'as_cell', 'AbstractCell', 'Cell', 'TensorProductCell',
-    'as_domain', 'AbstractDomain', 'Mesh', 'MeshView', 'TensorProductMesh',
+    'as_domain', 'AbstractDomain', 'Mesh', 'MeshView', 'TensorProductMesh', 'TopologicalMesh',
     'L2', 'H1', 'H2', 'HCurl', 'HDiv',
     'SpatialCoordinate',
     'CellVolume', 'CellDiameter', 'Circumradius',

--- a/ufl/__init__.py
+++ b/ufl/__init__.py
@@ -305,6 +305,9 @@ from ufl.constantvalue import PermutationSymbol, Identity, zero, as_ufl
 # Indexing of tensor expressions
 from ufl.core.multiindex import Index, indices
 
+# Transformed
+from ufl.transformed import Transformed
+
 # Special functions for expression base classes
 # (ensure this is imported, since it attaches operators to Expr)
 import ufl.exproperators as __exproperators
@@ -388,6 +391,7 @@ __all__ = [
     'Arguments', 'TestFunctions', 'TrialFunctions',
     'Coefficient', 'Coefficients', 'TopologicalCoefficient',
     'Constant', 'VectorConstant', 'TensorConstant',
+    'Transformed',
     'split',
     'PermutationSymbol', 'Identity', 'zero', 'as_ufl',
     'Index', 'indices',

--- a/ufl/algorithms/analysis.py
+++ b/ufl/algorithms/analysis.py
@@ -17,7 +17,7 @@ from ufl.utils.sorting import sorted_by_count, topological_sorting
 
 from ufl.core.terminal import Terminal, FormArgument
 from ufl.argument import Argument
-from ufl.coefficient import Coefficient
+from ufl.coefficient import Coefficient, TopologicalCoefficient
 from ufl.constant import Constant
 from ufl.algorithms.traversal import iter_expressions
 from ufl.corealg.traversal import unique_pre_traversal, traverse_unique_terminals
@@ -98,6 +98,12 @@ def extract_coefficients(a):
     """Build a sorted list of all coefficients in a,
     which can be a Form, Integral or Expr."""
     return sorted_by_count(extract_type(a, Coefficient))
+
+
+def extract_topological_coefficients(a):
+    """Build a sorted list of all topological coefficients in a,
+    which can be a Form, Integral or Expr."""
+    return sorted_by_count(extract_type(a, TopologicalCoefficient))
 
 
 def extract_constants(a):

--- a/ufl/algorithms/apply_derivatives.py
+++ b/ufl/algorithms/apply_derivatives.py
@@ -20,6 +20,7 @@ from ufl.classes import ConstantValue, Identity, Zero, FloatValue
 from ufl.classes import Coefficient, FormArgument, ReferenceValue
 from ufl.classes import Grad, ReferenceGrad, Variable
 from ufl.classes import Indexed, ListTensor, ComponentTensor
+from ufl.classes import Transformed
 from ufl.classes import ExprList, ExprMapping
 from ufl.classes import Product, Sum, IndexSum
 from ufl.classes import Conj, Real, Imag
@@ -83,6 +84,7 @@ class GenericDerivativeRuleset(MultiFunction):
         return o
     label = non_differentiable_terminal
     multi_index = non_differentiable_terminal
+    topological_coefficient = non_differentiable_terminal
 
     # --- Helper functions for creating zeros with the right shapes
 
@@ -197,6 +199,12 @@ class GenericDerivativeRuleset(MultiFunction):
         else:
             op = Indexed(Ap, ii)
         return op
+
+    def transformed(self, o, Ap, transform_op):
+        # Propagate zeros
+        if isinstance(Ap, Zero):
+            return self.independent_operator(o)
+        return Transformed(Ap, transform_op)
 
     def list_tensor(self, o, *dops):
         return ListTensor(*dops)
@@ -890,7 +898,7 @@ class GateauxDerivativeRuleset(GenericDerivativeRuleset):
         # Find o among all w without any indexing, which makes this
         # easy
         for (w, v) in zip(self._w, self._v):
-            if o == w and isinstance(v, FormArgument):
+            if o == w and isinstance(v, (FormArgument, Transformed)):
                 # Case: d/dt [w + t v]
                 return apply_grads(v)
 

--- a/ufl/algorithms/apply_restrictions.py
+++ b/ufl/algorithms/apply_restrictions.py
@@ -133,6 +133,8 @@ class RestrictionPropagator(MultiFunction):
         else:
             return self._require_restriction(o)
 
+    topological_coefficient = coefficient
+
     def facet_normal(self, o):
         D = o.ufl_domain()
         e = D.ufl_coordinate_element()

--- a/ufl/algorithms/apply_transforms.py
+++ b/ufl/algorithms/apply_transforms.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""This module contains the apply_transforms algorithm which propagates transform operators in a form towards the terminals."""
+
+# Copyright (C) 2008-2016 Martin Sandve Alnæs
+#
+# This file is part of UFL (https://www.fenicsproject.org)
+#
+# SPDX-License-Identifier:    LGPL-3.0-or-later
+
+
+from ufl.classes import FormArgument, Transformed
+from ufl.corealg.multifunction import MultiFunction
+from ufl.corealg.map_dag import map_expr_dag
+from ufl.algorithms.map_integrands import map_integrand_dags
+
+
+class TransformedRuleset(MultiFunction):
+    def __init__(self, transform_op):
+        MultiFunction.__init__(self)
+        self._transform_op = transform_op
+
+    def terminal(self, o):
+        return o
+
+    expr = MultiFunction.reuse_if_untouched
+
+    def reference_value(self, o):
+        "Must act directly on reference value of argument objects."
+        f, = o.ufl_operands
+        assert f._ufl_is_terminal_
+        assert isinstance(f, FormArgument)
+        return Transformed(o, self._transform_op)
+
+
+class TransformedRuleDispatcher(MultiFunction):
+    def __init__(self):
+        MultiFunction.__init__(self)
+
+    def terminal(self, o):
+        return o
+
+    expr = MultiFunction.reuse_if_untouched
+
+    def transformed(self, o, A, transform_op):
+        rules = TransformedRuleset(transform_op)
+        return map_expr_dag(rules, A)
+
+
+def apply_transforms(expression):
+    "Propagate filter nodes to wrap reference value argument directly."
+    rules = TransformedRuleDispatcher()
+    return map_integrand_dags(rules, expression)

--- a/ufl/algorithms/check_arities.py
+++ b/ufl/algorithms/check_arities.py
@@ -133,6 +133,7 @@ class ArityChecker(MultiFunction):
     indexed = linear_indexed_type
     index_sum = linear_indexed_type
     component_tensor = linear_indexed_type
+    transformed = linear_indexed_type
 
     def list_tensor(self, o, *ops):
         args = set(chain(*ops))

--- a/ufl/algorithms/domain_analysis.py
+++ b/ufl/algorithms/domain_analysis.py
@@ -30,7 +30,9 @@ class IntegralData(object):
     __slots__ = ('domain', 'integral_type', 'subdomain_id',
                  'integrals', 'metadata',
                  'integral_coefficients',
-                 'enabled_coefficients')
+                 'enabled_coefficients',
+                 'integral_topological_coefficients',
+                 'enabled_topological_coefficients')
 
     def __init__(self, domain, integral_type, subdomain_id, integrals,
                  metadata):
@@ -51,6 +53,8 @@ class IntegralData(object):
         # this stage:
         self.integral_coefficients = None
         self.enabled_coefficients = None
+        self.integral_topological_coefficients = None
+        self.enabled_topological_coefficients = None
 
         # TODO: I think we can get rid of this with some refactoring
         # in ffc:

--- a/ufl/algorithms/estimate_degrees.py
+++ b/ufl/algorithms/estimate_degrees.py
@@ -73,6 +73,11 @@ class SumDegreeEstimator(MultiFunction):
             d = self.default_degree
         return d
 
+    def topological_coefficient(self, v):
+        """A topological coefficient has no underlying geometry, and
+        must not be used in a way that it would contribute to the degree."""
+        return 0
+
     def _reduce_degree(self, v, f):
         """Reduces the estimated degree by one; used when derivatives
         are taken. Does not reduce the degree when TensorProduct elements
@@ -141,6 +146,9 @@ class SumDegreeEstimator(MultiFunction):
         return A
 
     def indexed(self, v, A, ii):
+        return A
+
+    def transformed(self, v, A, transform_op):
         return A
 
     def component_tensor(self, v, A, ii):

--- a/ufl/algorithms/formdata.py
+++ b/ufl/algorithms/formdata.py
@@ -36,6 +36,9 @@ class FormData(object):
             # Coefficients
             ("Number of coefficients", self.num_coefficients),
             ("Coefficients", lstr(self.reduced_coefficients)),
+            # TopologicalCoefficients
+            ("Number of topological coefficients", self.num_topological_coefficients),
+            ("Topological coefficients", lstr(self.reduced_topological_coefficients)),
             # Elements
             ("Unique elements", estr(self.unique_elements)),
             ("Unique sub elements", estr(self.unique_sub_elements)),

--- a/ufl/algorithms/signature.py
+++ b/ufl/algorithms/signature.py
@@ -10,7 +10,7 @@
 import hashlib
 from ufl.classes import (Label,
                          Index, MultiIndex,
-                         Coefficient, Argument,
+                         Coefficient, TopologicalCoefficient, Argument,
                          GeometricQuantity, ConstantValue, Constant,
                          ExprList, ExprMapping)
 from ufl.log import error
@@ -58,6 +58,9 @@ def compute_terminal_hashdata(expressions, renumbering):
                 data = expr._ufl_signature_data_(renumbering)
 
             elif isinstance(expr, Coefficient):
+                data = expr._ufl_signature_data_(renumbering)
+
+            elif isinstance(expr, TopologicalCoefficient):
                 data = expr._ufl_signature_data_(renumbering)
 
             elif isinstance(expr, Constant):

--- a/ufl/classes.py
+++ b/ufl/classes.py
@@ -37,6 +37,7 @@ import ufl.geometry
 # Operator types
 import ufl.averaging
 import ufl.indexed
+import ufl.transformed
 import ufl.indexsum
 import ufl.variable
 import ufl.tensors

--- a/ufl/functionspace.py
+++ b/ufl/functionspace.py
@@ -12,7 +12,7 @@
 
 from ufl.log import error
 from ufl.core.ufl_type import attach_operators_from_hash_data
-from ufl.domain import join_domains
+from ufl.domain import join_domains, TopologicalMesh
 
 # Export list for ufl.classes
 __all_classes__ = [
@@ -20,6 +20,7 @@ __all_classes__ = [
     "FunctionSpace",
     "MixedFunctionSpace",
     "TensorProductFunctionSpace",
+    "TopologicalFunctionSpace",
 ]
 
 
@@ -179,4 +180,76 @@ class MixedFunctionSpace(AbstractFunctionSpace):
 
     def __repr__(self):
         r = "MixedFunctionSpace(*%s)" % repr(self._ufl_function_spaces)
+        return r
+
+
+@attach_operators_from_hash_data
+class TopologicalFunctionSpace(AbstractFunctionSpace):
+    def __init__(self, domain, element):
+        assert isinstance(domain, TopologicalMesh), "domain must be an instance of TopologicalMesh, not of %s." % domain.__class__.__name__
+        if domain is None:
+            # DOLFIN hack
+            # TODO: Is anything expected from element.cell() in this case?
+            pass
+        else:
+            try:
+                domain_cell = domain.ufl_cell()
+            except AttributeError:
+                error("Expected non-abstract domain for initalization of topological function space.")
+            else:
+                if element.cell() != domain_cell:
+                    error("Non-matching cell of finite element and domain.")
+
+        AbstractFunctionSpace.__init__(self)
+        self._ufl_domain = domain
+        self._ufl_element = element
+
+    def ufl_sub_spaces(self):
+        "Return ufl sub spaces."
+        return ()
+
+    def ufl_domain(self):
+        "Return ufl domain."
+        return self._ufl_domain
+
+    def ufl_element(self):
+        "Return ufl element."
+        return self._ufl_element
+
+    def ufl_domains(self):
+        "Return ufl domains."
+        domain = self.ufl_domain()
+        if domain is None:
+            return ()
+        else:
+            return (domain,)
+
+    def _ufl_hash_data_(self):
+        domain = self.ufl_domain()
+        element = self.ufl_element()
+        if domain is None:
+            ddata = None
+        else:
+            ddata = domain._ufl_hash_data_()
+        if element is None:
+            edata = None
+        else:
+            edata = element._ufl_hash_data_()
+        return ("TopologicalFunctionSpace", ddata, edata)
+
+    def _ufl_signature_data_(self, renumbering):
+        domain = self.ufl_domain()
+        element = self.ufl_element()
+        if domain is None:
+            ddata = None
+        else:
+            ddata = domain._ufl_signature_data_(renumbering)
+        if element is None:
+            edata = None
+        else:
+            edata = element._ufl_signature_data_()
+        return ("TopologicalFunctionSpace", ddata, edata)
+
+    def __repr__(self):
+        r = "TopologicalFunctionSpace(%s, %s)" % (repr(self._ufl_domain), repr(self._ufl_element))
         return r

--- a/ufl/geometry.py
+++ b/ufl/geometry.py
@@ -15,7 +15,7 @@
 from ufl.log import error
 from ufl.core.ufl_type import ufl_type
 from ufl.core.terminal import Terminal
-from ufl.domain import as_domain
+from ufl.domain import as_domain, TopologicalMesh
 
 """
 
@@ -88,6 +88,7 @@ class GeometricQuantity(Terminal):
 
     def __init__(self, domain):
         Terminal.__init__(self)
+        assert not isinstance(domain, TopologicalMesh), "Unable to define GeometricQuantity on TopologicalMesh."
         self._domain = as_domain(domain)
 
     def ufl_domains(self):

--- a/ufl/transformed.py
+++ b/ufl/transformed.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""This module defines the Transformed class."""
+
+# Copyright (C) 2008-2016 Martin Sandve Alnæs
+#
+# This file is part of UFL (https://www.fenicsproject.org)
+#
+# SPDX-License-Identifier:    LGPL-3.0-or-later
+
+from ufl.constantvalue import Zero
+from ufl.core.ufl_type import ufl_type
+from ufl.core.operator import Operator
+from ufl.precedence import parstr
+
+
+@ufl_type(num_ops=2, is_terminal_modifier=True, inherit_shape_from_operand=0, inherit_indices_from_operand=0)
+class Transformed(Operator):
+    __slots__ = (
+        "ufl_shape",
+        "ufl_free_indices",
+        "ufl_index_dimensions",
+    )
+
+    def __new__(cls, expression, transform_op):
+        if isinstance(expression, Zero):
+            # Zero-simplify indexed Zero objects
+            shape = expression.ufl_shape
+            fi = expression.ufl_free_indices
+            fid = expression.ufl_index_dimensions
+            return Zero(shape=shape, free_indices=fi, index_dimensions=fid)
+        else:
+            return Operator.__new__(cls)
+
+    def __init__(self, expression, transform_op):
+        # Store operands
+        Operator.__init__(self, (expression, transform_op))
+
+    def ufl_element(self):
+        "Shortcut to get the finite element of the function space of the operand."
+        return self.ufl_operands[0].ufl_element()
+
+    def __str__(self):
+        return "%s[%s]" % (parstr(self.ufl_operands[0], self),
+                           self.ufl_operands[1])

--- a/ufl/transformed.py
+++ b/ufl/transformed.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 """This module defines the Transformed class."""
 
-# Copyright (C) 2008-2016 Martin Sandve Alnæs
+# Copyright (C) 2020 Imperial College London and others
 #
 # This file is part of UFL (https://www.fenicsproject.org)
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
+#
+# Written by Koki Sagiyama 2020
 
 from ufl.constantvalue import Zero
 from ufl.core.ufl_type import ufl_type


### PR DESCRIPTION
In this PR we propose a new class, **ufl.Transformed**, and several supporting classes.

`Transformed` will let finite element analysis programs such as FEniCS and Firedrake monolithicaly treat, e.g.:

- DirichletBC,
- EquationBC (domain dofs and boundary dofs satisfy distinct PDEs),
- Strong zero-normal velocity condition on tilted plane boundaries (Stokes problem).

Mathematically, `Transformed` represents a linear transformation, {v_} = {L}{v}, where {v} is a discretised (test/trial) function that is represented by a `FromArgumant` `v` defined on `V`,
and {L} is a linear transformation operator; for now we only consider cases where
{L} is diagonal, having the same discrete dimensionality as {v}, and in the following we denote
the diagonal entries of {L} by {l}.
In terms of the dimensionallity, {l} could be represented in UFL by a `Coefficient` (defined
on V), but the values in {l} are just scalar values attached to each basis, and
nothing more; values between two nodes, for instance, is of no interest, nor the gradient of this symbolic object.
This motivated us to introduce `TopologicalCoefficient` class that is like `Coefficient`, but has no knowledge of coordinates, and `TopologicalCoefficient` naturally necessitates `TopologicalFunctionSpace` and `TopologicalMesh`.
If we define `V` as:
`V = FunctionSpace(msh, element)`,
we define:
`tV = TopologicalFunctionSpace(tmsh, element)`,
where `tmsh` is a `TopologicalMesh` corresponding to `msh`. We can then have {l} represented by `l`: `TopologicalCoeffient` defined on `tV`.

The proposed usage of this new class in FEniCS/Firedrake is:

`v_ = Transformed(v, l)`,

and a form compiler is to multiply {l}_i when i^th basis appear in the context of `v`; e.g. if `v` is a test function, {l}_i is to be multiplied when assembling the i^th row of a residual vector/jacobian matrix.

If values in {l} are 0 or 1, the above represents a projection of `v` onto a smaller finite element space spanned by basis functions whose associated values in {l} are set 1.
This is best illustrated in the following example:

Ex: Pseudo FEniCS/Firedrake code to solve poisson's equation with Dirichlet BC, u = g.
```
v = TestFunction(V)
u = TrialFunction(V)
l0 = TopologicalCoefficient( 1 for interior basis and 0 for boundary basis )
l1 = TopologicalCoefficient( 0 for interior basis and 1 for boundary basis )
v0 = Transformed(v, l0)
v1 = Transformed(v, l1)
a = inner(grad(u), grad(v0)) * dx + inner((u - g), v1) * ds
L = ...
solve(a == L, ...)
```
(By appropriately using `Transformed(u, l0)` and `Transformed(u, l1)`, one can also symmetrise the system.)

The above example shows that `Transformed` lets users have a fine control of the basis set they assemble equations for. As such, `Transformed`, to some extent, can be regarded as a generalisation of `Indexed`, and indeed the implementation of `Transformed` mimics that of `Indexed` and `Transformed` is defined as a `terminal_modifier`.

Though one can solve the above example using `DirichletBC` class, `Transformed` will allow for higher flexibility in forming equations.  For instance, defining:

`a = B0(u, v0) * dx + B1(u, v1) * dx`

in the above example lets one solve B0 in the domain and B1 on the boundary. Of note here is that the second term is only assembled into the rows of residual/Jacobian associated with boundary dofs, but it is a cell integration; this is useful when applying zero-normal velocity boundary condition in Stokes problem, as the PDE tested against the tangential component of test function has a cell integral, but it has to be solved on the boundary. 