### PR TITLE
setup: Ignore ambiguous variable names for flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [flake8]
-ignore = E501, W504
+ignore = E501, W504,
+         E741                   # ambiguous variable name
 builtins = ufl
 exclude = .git,__pycache__,doc/sphinx/source/conf.py,build,dist,test
 


### PR DESCRIPTION
Update for new flake8 requirements.