### PR TITLE
Group integrals after degree estimation

### DIFF
--- a/ufl/algorithms/compute_form_data.py
+++ b/ufl/algorithms/compute_form_data.py
@@ -264,18 +264,18 @@ def compute_form_data(form,
     # user-defined coefficient relations it just gets too messy
     form = apply_derivatives(form)
 
+    # Estimate polynomial degree of integrands now, before applying
+    # any pullbacks and geometric lowering.  Otherwise quad degrees
+    # blow up horrifically.
+    if do_estimate_degrees:
+        form = attach_estimated_degrees(form)
+
     # --- Group form integrals
     # TODO: Refactor this, it's rather opaque what this does
     # TODO: Is self.original_form.ufl_domains() right here?
     #       It will matter when we start including 'num_domains' in ufc form.
     form = group_form_integrals(form, self.original_form.ufl_domains(),
                                 do_append_everywhere_integrals=do_append_everywhere_integrals)
-
-    # Estimate polynomial degree of integrands now, before applying
-    # any pullbacks and geometric lowering.  Otherwise quad degrees
-    # blow up horrifically.
-    if do_estimate_degrees:
-        form = attach_estimated_degrees(form)
 
     if do_apply_function_pullbacks:
         # Rewrite coefficients and arguments in terms of their


### PR DESCRIPTION
This PR first runs degree estimation on integrals, which attaches estimated polynomial degree as a integrand's metadata. It groups integrals only after.

This has several performance implications. E.g. in the current master
`u*v*dx + inner(grad(u), grad(v))*dx` would be grouped into one integral `(u*v + inner(grad(u), grad(v)))*dx` for which one polynomial degree is estimated. Note this degree is too high for the mass operator term.

With this PR it becomes for `P_k` functions (and affine geometry)
`u*v*dx(metadata={"est_degree": k**2}) + inner(grad(v), grad(v))*dx(metadata={"est_degree": (k-1)**2})`
and these integrals **won't** be later grouped by UFL.