### PR TITLE
Fix issue #36

### DIFF
--- a/ufl/finiteelement/mixedelement.py
+++ b/ufl/finiteelement/mixedelement.py
@@ -295,8 +295,7 @@ class VectorElement(MixedElement):
         # Initialize element data
         MixedElement.__init__(self, sub_elements, value_shape=value_shape,
                               reference_value_shape=reference_value_shape)
-        FiniteElementBase.__init__(self, sub_element.family(), cell, sub_element.degree(), quad_scheme,
-                                   value_shape, reference_value_shape)
+
         self._sub_element = sub_element
 
         # Cache repr string


### PR DESCRIPTION
The removed code overwrites some properties for whatever reason, in particular, quad_scheme.
In `TensorElement` these two lines were not there at all and I do not think that they are required for `VectorElement`.