### PR TITLE
Add KMV element, which admits mass lumping on the simplex

### DIFF
--- a/ufl/finiteelement/elementlist.py
+++ b/ufl/finiteelement/elementlist.py
@@ -125,6 +125,8 @@ register_element("Crouzeix-Raviart", "CR", 0, L2, "identity", (1, 1),
 register_element("Discontinuous Raviart-Thomas", "DRT", 1, L2,
                  "contravariant Piola", (1, None), simplices[1:])
 register_element("Hermite", "HER", 0, H1, "identity", (3, 3), simplices)
+register_element("KongMulderVeldhuizen", "KMV", 0, H1, "identity", (1, None),
+                 simplices[1:])
 register_element("Mardal-Tai-Winther", "MTW", 0, H1, "identity", None,
                  ("triangle",))
 register_element("Morley", "MOR", 0, H2, "identity", (2, 2), ("triangle",))

--- a/ufl/finiteelement/elementlist.py
+++ b/ufl/finiteelement/elementlist.py
@@ -124,7 +124,7 @@ register_element("Crouzeix-Raviart", "CR", 0, L2, "identity", (1, 1),
 register_element("Discontinuous Raviart-Thomas", "DRT", 1, L2,
                  "contravariant Piola", (1, None), simplices[1:])
 register_element("Hermite", "HER", 0, H1, "identity", (3, 3), simplices)
-register_element("KongMulderVeldhuizen", "KMV", 0, H1, "identity", (1, None),
+register_element("Kong-Mulder-Veldhuizen", "KMV", 0, H1, "identity", (1, None),
                  simplices[1:])
 register_element("Mardal-Tai-Winther", "MTW", 0, H1, "identity", None,
                  ("triangle",))


### PR DESCRIPTION
Registering new Kong-Mulder-Veldhuizen simplicial elements  that need to land with #59 in FIAT https://github.com/FEniCS/fiat/pull/59 