### PR TITLE
Allow Q1 calculation of CellDiameter to work for tensor product cells

### DIFF
--- a/ufl/algorithms/apply_geometry_lowering.py
+++ b/ufl/algorithms/apply_geometry_lowering.py
@@ -295,7 +295,7 @@ class GeometryLoweringApplier(MultiFunction):
 
         domain = o.ufl_domain()
 
-        if not domain.ufl_coordinate_element().degree() == 1:
+        if not domain.ufl_coordinate_element().degree() in {1, (1, 1)}:
             # Don't lower bendy cells, instead leave it to form compiler
             warning("Only know how to compute cell diameter of P1 or Q1 cell.")
             return o


### PR DESCRIPTION
Without this, `CellDiameter` doesn't work on meshes constructed via extrusion.