### PR TITLE
use complex-coordinate-space distance in GeometryLoweringApplier

### DIFF
--- a/ufl/algorithms/apply_geometry_lowering.py
+++ b/ufl/algorithms/apply_geometry_lowering.py
@@ -37,7 +37,7 @@ from ufl.classes import (Expr, Form, Integral,
 # FacetOrientation, QuadratureWeight,
 
 from ufl.tensors import as_tensor, as_vector
-from ufl.operators import sqrt, max_value, min_value
+from ufl.operators import sqrt, max_value, min_value, conj, real
 
 from ufl.compound_expressions import determinant_expr, cross_expr, inverse_expr
 
@@ -238,7 +238,7 @@ class GeometryLoweringApplier(MultiFunction):
         edges = CellEdgeVectors(domain)
         num_edges = edges.ufl_shape[0]
         j = Index()
-        elen = [sqrt(edges[e, j] * edges[e, j]) for e in range(num_edges)]
+        elen = [real(sqrt(real(edges[e, j] * conj(edges[e, j])))) for e in range(num_edges)]
 
         if cellname == "triangle":
             return (elen[0] * elen[1] * elen[2]) / (4.0 * cellvolume)
@@ -285,8 +285,8 @@ class GeometryLoweringApplier(MultiFunction):
             edges = CellEdgeVectors(domain)
             num_edges = edges.ufl_shape[0]
             j = Index()
-            elen2 = [edges[e, j] * edges[e, j] for e in range(num_edges)]
-            return sqrt(reduce(reduction_op, elen2))
+            elen2 = [real(edges[e, j] * conj(edges[e, j])) for e in range(num_edges)]
+            return real(sqrt(reduce(reduction_op, elen2)))
 
     @memoized_handler
     def cell_diameter(self, o):
@@ -309,8 +309,8 @@ class GeometryLoweringApplier(MultiFunction):
             verts = CellVertices(domain)
             verts = [verts[v, ...] for v in range(verts.ufl_shape[0])]
             j = Index()
-            elen2 = ((v0 - v1)[j] * (v0 - v1)[j] for v0, v1 in combinations(verts, 2))
-            return sqrt(reduce(max_value, elen2))
+            elen2 = (real((v0 - v1)[j] * conj((v0 - v1)[j])) for v0, v1 in combinations(verts, 2))
+            return real(sqrt(reduce(max_value, elen2)))
 
     @memoized_handler
     def max_facet_edge_length(self, o):
@@ -339,8 +339,8 @@ class GeometryLoweringApplier(MultiFunction):
             edges = FacetEdgeVectors(domain)
             num_edges = edges.ufl_shape[0]
             j = Index()
-            elen2 = [edges[e, j] * edges[e, j] for e in range(num_edges)]
-            return sqrt(reduce(reduction_op, elen2))
+            elen2 = [real(edges[e, j] * conj(edges[e, j])) for e in range(num_edges)]
+            return real(sqrt(reduce(reduction_op, elen2)))
 
     @memoized_handler
     def cell_normal(self, o):


### PR DESCRIPTION
This PR is to use complex-coordinate-space distance in `GeometryLoweringApplier` to make this class safe to use in complex mode.