### PR TITLE
Fix registration of MTW elements again

### DIFF
--- a/test/test_elements.py
+++ b/test/test_elements.py
@@ -121,6 +121,14 @@ def test_vector_bdm():
         assert element == eval(repr(element))
 
 
+def test_mtw():
+    cell = triangle
+    element = FiniteElement("MTW", cell, 3)
+    assert element.value_shape() == (cell.geometric_dimension(), )
+    assert element == eval(repr(element))
+    assert element.mapping() == "contravariant Piola"
+
+
 def test_mixed():
     for cell in (triangle, tetrahedron):
         dim = cell.geometric_dimension()

--- a/ufl/finiteelement/elementlist.py
+++ b/ufl/finiteelement/elementlist.py
@@ -126,7 +126,7 @@ register_element("Discontinuous Raviart-Thomas", "DRT", 1, L2,
 register_element("Hermite", "HER", 0, H1, "identity", (3, 3), simplices)
 register_element("Kong-Mulder-Veldhuizen", "KMV", 0, H1, "identity", (1, None),
                  simplices[1:])
-register_element("Mardal-Tai-Winther", "MTW", 0, H1, "identity", (3, 3),
+register_element("Mardal-Tai-Winther", "MTW", 1, H1, "contravariant Piola", (3, 3),
                  ("triangle",))
 register_element("Morley", "MOR", 0, H2, "identity", (2, 2), ("triangle",))
 


### PR DESCRIPTION
Value-rank and mapping were both reported incorrectly in a botched
merge. Fix and add a test to check them.