### PR TITLE
Add degree argument to tensor product element reconstruction

### DIFF
--- a/ufl/finiteelement/tensorproductelement.py
+++ b/ufl/finiteelement/tensorproductelement.py
@@ -17,7 +17,8 @@ from ufl.log import error
 from ufl.cell import TensorProductCell, as_cell
 from ufl.sobolevspace import DirectionalSobolevSpace
 
-from ufl.finiteelement.finiteelementbase import FiniteElementBase, FiniteElement
+from ufl.finiteelement.finiteelementbase import FiniteElementBase
+from ufl.finiteelement.finiteelement import FiniteElement
 
 from collections.abc import Iterable
 

--- a/ufl/finiteelement/tensorproductelement.py
+++ b/ufl/finiteelement/tensorproductelement.py
@@ -19,6 +19,8 @@ from ufl.sobolevspace import DirectionalSobolevSpace
 
 from ufl.finiteelement.finiteelementbase import FiniteElementBase, FiniteElement
 
+from collections.abc import Iterable
+
 
 class TensorProductElement(FiniteElementBase):
     r"""The tensor product of :math:`d` element spaces:
@@ -111,6 +113,11 @@ class TensorProductElement(FiniteElementBase):
                                                         subel.cell(),
                                                         degree)
                                           for subel in self.sub_elements()])
+        elif isinstance(degree, Iterable):
+            return TensorProductElement(*[FiniteElement(subel.family(),
+                                                        subel.cell(),
+                                                        deg)
+                                          for (subel, deg) in zip(self.sub_elements(), degree)])
 
     def __str__(self):
         "Pretty-print."

--- a/ufl/finiteelement/tensorproductelement.py
+++ b/ufl/finiteelement/tensorproductelement.py
@@ -17,7 +17,7 @@ from ufl.log import error
 from ufl.cell import TensorProductCell, as_cell
 from ufl.sobolevspace import DirectionalSobolevSpace
 
-from ufl.finiteelement.finiteelementbase import FiniteElementBase
+from ufl.finiteelement.finiteelementbase import FiniteElementBase, FiniteElement
 
 
 class TensorProductElement(FiniteElementBase):
@@ -103,8 +103,14 @@ class TensorProductElement(FiniteElementBase):
         "Return subelements (factors)."
         return self._sub_elements
 
-    def reconstruct(self, cell=None):
-        return TensorProductElement(*self.sub_elements(), cell=cell)
+    def reconstruct(self, cell=None, degree=None):
+        if degree is None:
+            return TensorProductElement(*self.sub_elements(), cell=cell)
+        elif isinstance(degree, int):
+            return TensorProductElement(*[FiniteElement(subel.family(),
+                                                        subel.cell(),
+                                                        degree)
+                                          for subel in self.sub_elements()])
 
     def __str__(self):
         "Pretty-print."


### PR DESCRIPTION
In using low-order preconditioners, we need to reconstruct a finite element with a lower-degree instance of the same element family.  This PR enables this for tensor product elements.