### PR TITLE
Fix algorithmic scaling with number of subdomains for __rmul__

### DIFF
--- a/ufl/measure.py
+++ b/ufl/measure.py
@@ -12,6 +12,8 @@
 
 import numbers
 
+from itertools import chain
+
 from ufl.log import error, deprecate
 from ufl.core.expr import Expr
 from ufl.checks import is_true_ufl_scalar
@@ -407,11 +409,12 @@ class Measure(object):
                   "tensor expression with value shape %s and free indices with labels %s." %
                   (integrand.ufl_shape, integrand.ufl_free_indices))
 
-        # If we have a tuple of domain ids, delegate composition to
-        # Integral.__add__:
+        # If we have a tuple of domain ids build the integrals one by
+        # one and construct as a Form in one go.
         subdomain_id = self.subdomain_id()
         if isinstance(subdomain_id, tuple):
-            return sum(integrand * self.reconstruct(subdomain_id=d) for d in subdomain_id)
+            return Form(list(chain(*((integrand * self.reconstruct(subdomain_id=d)).integrals()
+                                     for d in subdomain_id))))
 
         # Check that we have an integer subdomain or a string
         # ("everywhere" or "otherwise", any more?)


### PR DESCRIPTION
Rather than delegating to Form.__add__ for constructing forms with
multiple subdomain ids, build the integrals once individually and then
construct a single Form at the end. This avoids an O(N^2 log N)
algorithm (due to a sorting of the integrals each time in
Form.__init__).

Before:

    import time
    for n in range(0, 1001, 100):
        ids = tuple(range(n))
        start = time.time()
        expr = f*dx(ids)
        end = time.time()
        print(f"{n} {end-start:.3f}s")

0 0.000s
100 0.021s
200 0.076s
300 0.156s
400 0.258s
500 0.396s
600 0.569s
700 0.759s
800 1.041s
900 1.290s
1000 1.761s

After:

0 0.000s
100 0.005s
200 0.007s
300 0.011s
400 0.013s
500 0.015s
600 0.022s
700 0.024s
800 0.026s
900 0.028s
1000 0.034s

Other parts of the pipeline are still slow with many subdomain ids,
but this is a start.