### PR TITLE
Add functions to strip and attach data references in forms

### DIFF
--- a/test/test_strip_forms.py
+++ b/test/test_strip_forms.py
@@ -1,0 +1,106 @@
+import gc
+import sys
+
+import pytest
+
+from ufl import *
+from ufl.algorithms import strip_terminal_data, replace_terminal_data
+from ufl.core.ufl_id import attach_ufl_id
+from ufl.core.ufl_type import attach_operators_from_hash_data
+
+
+MIN_REF_COUNT = 2
+"""The minimum value returned by sys.getrefcount."""
+
+
+@attach_operators_from_hash_data
+@attach_ufl_id
+class AugmentedMesh(Mesh):
+    def __init__(self, *args, data):
+        super().__init__(*args)
+        self.data = data
+
+
+@attach_operators_from_hash_data
+class AugmentedFunctionSpace(FunctionSpace):
+    def __init__(self, *args, data):
+        super().__init__(*args)
+        self.data = data
+
+
+class AugmentedCoefficient(Coefficient):
+    def __init__(self, *args, data):
+        super().__init__(*args)
+        self.data = data
+
+
+class AugmentedConstant(Constant):
+    def __init__(self, *args, data):
+        super().__init__(*args)
+        self.data = data
+
+
+def test_strip_form_arguments_strips_data_refs():
+    mesh_data = object()
+    fs_data = object()
+    coeff_data = object()
+    const_data = object()
+
+    # Sanity check
+    assert sys.getrefcount(mesh_data) == MIN_REF_COUNT
+    assert sys.getrefcount(fs_data) == MIN_REF_COUNT
+    assert sys.getrefcount(coeff_data) == MIN_REF_COUNT
+    assert sys.getrefcount(const_data) == MIN_REF_COUNT
+
+    cell = triangle
+    domain = AugmentedMesh(cell, data=mesh_data)
+    element = FiniteElement("Lagrange", cell, 1)
+    V = AugmentedFunctionSpace(domain, element, data=fs_data)
+
+    v = TestFunction(V)
+    u = TrialFunction(V)
+    f = AugmentedCoefficient(V, data=coeff_data)
+    k = AugmentedConstant(V, data=const_data)
+
+    form = k*f*inner(grad(v), grad(u))*dx
+
+    # Remove extraneous references
+    del cell, domain, element, V, v, u, f, k
+
+    assert sys.getrefcount(mesh_data) == MIN_REF_COUNT + 1
+    assert sys.getrefcount(fs_data) == MIN_REF_COUNT + 1
+    assert sys.getrefcount(coeff_data) == MIN_REF_COUNT + 1
+    assert sys.getrefcount(const_data) == MIN_REF_COUNT + 1
+
+    stripped_form, mapping = strip_terminal_data(form)
+
+    del form, mapping
+    gc.collect()  # This is needed to update the refcounts
+
+    assert sys.getrefcount(mesh_data) == MIN_REF_COUNT
+    assert sys.getrefcount(fs_data) == MIN_REF_COUNT
+    assert sys.getrefcount(coeff_data) == MIN_REF_COUNT
+    assert sys.getrefcount(const_data) == MIN_REF_COUNT
+
+
+def test_strip_form_arguments_does_not_change_form():
+    mesh_data = object()
+    fs_data = object()
+    coeff_data = object()
+    const_data = object()
+
+    cell = triangle
+    domain = AugmentedMesh(cell, data=mesh_data)
+    element = FiniteElement("Lagrange", cell, 1)
+    V = AugmentedFunctionSpace(domain, element, data=fs_data)
+
+    v = TestFunction(V)
+    u = TrialFunction(V)
+    f = AugmentedCoefficient(V, data=coeff_data)
+    k = AugmentedConstant(V, data=const_data)
+
+    form = k*f*inner(grad(v), grad(u))*dx
+    stripped_form, mapping = strip_terminal_data(form)
+
+    assert stripped_form.signature() == form.signature()
+    assert replace_terminal_data(stripped_form, mapping) == form

--- a/ufl/algorithms/__init__.py
+++ b/ufl/algorithms/__init__.py
@@ -37,6 +37,8 @@ __all__ = [
     "expand_derivatives",
     "extract_coefficients",
     "strip_variables",
+    "strip_terminal_data",
+    "replace_terminal_data",
     "post_traversal",
     "change_to_reference_grad",
     "expand_compounds",
@@ -93,6 +95,8 @@ from ufl.algorithms.transformer import Transformer, ReuseTransformer
 # from ufl.algorithms.transformer import is_post_handler
 from ufl.algorithms.transformer import apply_transformer
 from ufl.algorithms.transformer import strip_variables
+from ufl.algorithms.strip_terminal_data import strip_terminal_data
+from ufl.algorithms.strip_terminal_data import replace_terminal_data
 # from ufl.algorithms.replace import Replacer
 from ufl.algorithms.replace import replace
 from ufl.algorithms.change_to_reference import change_to_reference_grad

--- a/ufl/algorithms/strip_terminal_data.py
+++ b/ufl/algorithms/strip_terminal_data.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+"""Algorithm for replacing form arguments with 'stripped' versions where any
+data-carrying objects have been extracted to a mapping."""
+
+from ufl.classes import Form, Integral
+from ufl.classes import Argument, Coefficient, Constant
+from ufl.classes import FunctionSpace, TensorProductFunctionSpace, MixedFunctionSpace
+from ufl.classes import Mesh, MeshView, TensorProductMesh
+from ufl.algorithms.replace import replace
+from ufl.corealg.map_dag import map_expr_dag
+from ufl.corealg.multifunction import MultiFunction
+
+
+class TerminalStripper(MultiFunction):
+    def __init__(self):
+        super().__init__()
+        self.mapping = {}
+
+    def argument(self, o):
+        o_new = Argument(strip_function_space(o.ufl_function_space()),
+                         o.number(), o.part())
+        return self.mapping.setdefault(o, o_new)
+
+    def coefficient(self, o):
+        o_new = Coefficient(strip_function_space(o.ufl_function_space()),
+                            o.count())
+        return self.mapping.setdefault(o, o_new)
+
+    def constant(self, o):
+        o_new = Constant(strip_domain(o.ufl_domain()), o.ufl_shape,
+                         o.count())
+        return self.mapping.setdefault(o, o_new)
+
+    expr = MultiFunction.reuse_if_untouched
+
+
+def strip_terminal_data(o):
+    """Return a new form where all terminals have been replaced by UFL-only
+    equivalents.
+
+    :arg o: The object to be stripped. This must either be a :class:`~.Form`
+        or :class:`~.Integral`.
+    :returns: A 2-tuple containing an equivalent UFL-only object and a mapping
+        allowing the original form to be reconstructed using
+        :func:`replace_terminal_data`.
+
+    This function is useful for forms containing augmented UFL objects that
+    hold references to large data structures. These objects are be extracted
+    into the mapping allowing the form to be cached without leaking memory.
+    """
+    # We need to keep track of two maps because integrals store references to the
+    # domain and ``replace`` expects only a mapping containing ``Expr`` objects.
+    if isinstance(o, Form):
+        integrals = []
+        expr_map = {}
+        domain_map = {}
+        for integral in o.integrals():
+            itg, (emap, dmap) = strip_terminal_data(integral)
+            integrals.append(itg)
+            expr_map.update(emap)
+            domain_map.update(dmap)
+        return Form(integrals), (expr_map, domain_map)
+    elif isinstance(o, Integral):
+        handler = TerminalStripper()
+        integrand = map_expr_dag(handler, o.integrand())
+        domain = strip_domain(o.ufl_domain())
+        # invert the mapping so it can be passed straight into replace_terminal_data
+        expr_map = {v: k for k, v in handler.mapping.items()}
+        domain_map = {domain: o.ufl_domain()}
+        return o.reconstruct(integrand, domain=domain), (expr_map, domain_map)
+    else:
+        raise ValueError("Only Form or Integral inputs expected")
+
+
+def replace_terminal_data(o, mapping):
+    """Return a new form where the terminals have been replaced using the
+    provided mapping.
+
+    :arg o: The object to have its terminals replaced. This must either be a
+        :class:`~.Form` or :class:`~.Integral`.
+    :arg mapping: A mapping suitable for reconstructing the form such as the one
+        returned by :func:`strip_terminal_data`.
+    :returns: The new form.
+    """
+    if isinstance(o, Form):
+        return Form([replace_terminal_data(itg, mapping) for itg in o.integrals()])
+    elif isinstance(o, Integral):
+        expr_map, domain_map = mapping
+        integrand = replace(o.integrand(), expr_map)
+        return o.reconstruct(integrand, domain=domain_map[o.ufl_domain()])
+    else:
+        raise ValueError("Only Form or Integral inputs expected")
+
+
+def strip_function_space(function_space):
+    "Return a new function space with all non-UFL information removed."
+    if isinstance(function_space, FunctionSpace):
+        return FunctionSpace(strip_domain(function_space.ufl_domain()),
+                             function_space.ufl_element())
+    elif isinstance(function_space, TensorProductFunctionSpace):
+        subspaces = [strip_function_space(sub) for sub in function_space.ufl_sub_spaces()]
+        return TensorProductFunctionSpace(*subspaces)
+    elif isinstance(function_space, MixedFunctionSpace):
+        subspaces = [strip_function_space(sub) for sub in function_space.ufl_sub_spaces()]
+        return MixedFunctionSpace(*subspaces)
+    else:
+        raise NotImplementedError(f"{type(function_space)} cannot be stripped")
+
+
+def strip_domain(domain):
+    "Return a new domain with all non-UFL information removed."
+    if isinstance(domain, Mesh):
+        return Mesh(domain.ufl_coordinate_element(), domain.ufl_id())
+    elif isinstance(domain, MeshView):
+        return MeshView(strip_domain(domain.ufl_mesh()),
+                        domain.topological_dimension(), domain.ufl_id())
+    elif isinstance(domain, TensorProductMesh):
+        meshes = [strip_domain(mesh) for mesh in domain.ufl_meshes()]
+        return TensorProductMesh(meshes, domain.ufl_id())
+    else:
+        raise NotImplementedError(f"{type(domain)} cannot be stripped")

--- a/ufl/domain.py
+++ b/ufl/domain.py
@@ -209,6 +209,9 @@ class TensorProductMesh(AbstractDomain):
     def ufl_cell(self):
         return self._ufl_cell
 
+    def ufl_meshes(self):
+        return self._ufl_meshes
+
     def is_piecewise_linear_simplex_domain(self):
         return False  # TODO: Any cases this is True
 


### PR DESCRIPTION
This change adds two new functions: `strip_terminal_data` and `replace_terminal_data`.
The former takes a form as input and returns a new 'stripped' form, where the terminals have been replaced with UFL-only equivalents, and a mapping to allow one to reconstruct the original form with `replace_terminal_data`.

These functions will make it easier to cache forms in Firedrake and other libraries that use UFL.
Currently caching forms is an issue because they contain subclassed UFL objects where data has been attached to them (e.g. a Firedrake `Function`).
The advantage to producing 'stripped' forms is that they do not hold these data references and can be safely cached without introducing a memory leak.