### PR TITLE
Catch users who try to index UFL expressions with negative indices

### DIFF
--- a/ufl/indexed.py
+++ b/ufl/indexed.py
@@ -62,7 +62,7 @@ class Indexed(Operator):
             error("Invalid number of indices (%d) for tensor "
                   "expression of rank %d:\n\t%s\n"
                   % (len(multiindex), len(expression.ufl_shape), ufl_err_str(expression)))
-        if any(int(di) >= int(si)
+        if any(int(di) >= int(si) or int(di) < 0
                for si, di in zip(shape, multiindex)
                if isinstance(di, FixedIndex)):
             error("Fixed index out of range!")


### PR DESCRIPTION
I had code where I wanted to access the last component of a vector expression, and used `expr[-1]`. It turns out that UFL indices don't wrap-around, and it just caused an obscure error in the form compiler later. This patch catches such user errors at a more useful stage.