### PR TITLE
Refactor pullback application

### DIFF
--- a/test/test_apply_function_pullbacks.py
+++ b/test/test_apply_function_pullbacks.py
@@ -1,32 +1,34 @@
 #!/usr/bin/env py.test
 # -*- coding: utf-8 -*-
 
-from pytest import raises
+import numpy
 from ufl import *
-from ufl.algorithms.apply_function_pullbacks import apply_function_pullbacks, apply_single_function_pullbacks
+from ufl.algorithms.apply_function_pullbacks import apply_single_function_pullbacks
 from ufl.algorithms.renumbering import renumber_indices
 from ufl.classes import Jacobian, JacobianInverse, JacobianDeterminant, ReferenceValue, CellOrientation
 
 
 def check_single_function_pullback(g, mappings):
     expected = mappings[g]
-    actual = apply_single_function_pullbacks(g)
-    rexp = renumber_indices(expected)
-    ract = renumber_indices(actual)
-    if not rexp == ract:
-        print()
-        print("In check_single_function_pullback:")
-        print("input:")
-        print(repr(g))
-        print("expected:")
-        print(str(rexp))
-        print("actual:")
-        print(str(ract))
-        print("signatures:")
-        print((expected**2*dx).signature())
-        print((actual**2*dx).signature())
-        print()
-    assert ract == rexp
+    actual = apply_single_function_pullbacks(ReferenceValue(g), g.ufl_element())
+    assert expected.ufl_shape == actual.ufl_shape
+    for idx in numpy.ndindex(actual.ufl_shape):
+        rexp = renumber_indices(expected[idx])
+        ract = renumber_indices(actual[idx])
+        if not rexp == ract:
+            print()
+            print("In check_single_function_pullback:")
+            print("input:")
+            print(repr(g))
+            print("expected:")
+            print(str(rexp))
+            print("actual:")
+            print(str(ract))
+            print("signatures:")
+            print((expected**2*dx).signature())
+            print((actual**2*dx).signature())
+            print()
+        assert ract == rexp
 
 
 def test_apply_single_function_pullbacks_triangle3d():
@@ -131,7 +133,7 @@ def test_apply_single_function_pullbacks_triangle3d():
                       [rs[1], rs[3], rs[4]],
                       [rs[2], rs[4], rs[5]]]),
         cov2t: as_tensor(Jinv[k, i] * rcov2t[k, l] * Jinv[l, j], (i, j)),
-        contra2t: as_tensor((1.0 / detJ) * (1.0 / detJ)
+        contra2t: as_tensor((1.0 / detJ)**2
                             * J[i, k] * rcontra2t[k, l] * J[j, l], (i, j)),
         # Mixed elements become a bit more complicated
         uml2: as_vector([ruml2[0] / detJ, ruml2[1] / detJ]),
@@ -143,25 +145,21 @@ def test_apply_single_function_pullbacks_triangle3d():
             rvdm[1],
             rvdm[2],
             # Vd
-            M_hdiv[0, j]*as_vector([rvdm[3], rvdm[4]])[j],
-            M_hdiv[1, j]*as_vector([rvdm[3], rvdm[4]])[j],
-            M_hdiv[2, j]*as_vector([rvdm[3], rvdm[4]])[j],
+            *(as_tensor(M_hdiv[i, j]*as_vector([rvdm[3], rvdm[4]])[j], (i,))[n]
+              for n in range(3))
     ]),
         vcm: as_vector([
             # Vd
-            M_hdiv[0, j]*as_vector([rvcm[0], rvcm[1]])[j],
-            M_hdiv[1, j]*as_vector([rvcm[0], rvcm[1]])[j],
-            M_hdiv[2, j]*as_vector([rvcm[0], rvcm[1]])[j],
+            *(as_tensor(M_hdiv[i, j]*as_vector([rvcm[0], rvcm[1]])[j], (i,))[n]
+              for n in range(3)),
             # Vc
-            Jinv[i, 0]*as_vector([rvcm[2], rvcm[3]])[i],
-            Jinv[i, 1]*as_vector([rvcm[2], rvcm[3]])[i],
-            Jinv[i, 2]*as_vector([rvcm[2], rvcm[3]])[i],
+            *(as_tensor(Jinv[i, j]*as_vector([rvcm[2], rvcm[3]])[i], (j,))[n]
+              for n in range(3))
     ]),
         tm: as_vector([
             # Vc
-            Jinv[i, 0]*as_vector([rtm[0], rtm[1]])[i],
-            Jinv[i, 1]*as_vector([rtm[0], rtm[1]])[i],
-            Jinv[i, 2]*as_vector([rtm[0], rtm[1]])[i],
+            *(as_tensor(Jinv[i, j]*as_vector([rtm[0], rtm[1]])[i], (j,))[n]
+              for n in range(3)),
             # T
             rtm[2], rtm[3], rtm[4],
             rtm[5], rtm[6], rtm[7],
@@ -195,13 +193,11 @@ def test_apply_single_function_pullbacks_triangle3d():
             rw[9], rw[10], rw[11],
             rw[12], rw[13], rw[14],
             # Vc
-            Jinv[i, 0]*as_vector([rw[15], rw[16]])[i],
-            Jinv[i, 1]*as_vector([rw[15], rw[16]])[i],
-            Jinv[i, 2]*as_vector([rw[15], rw[16]])[i],
+            *(as_tensor(Jinv[i, j]*as_vector([rw[15], rw[16]])[i], (j,))[n]
+              for n in range(3)),
             # Vd
-            M_hdiv[0, j]*as_vector([rw[17], rw[18]])[j],
-            M_hdiv[1, j]*as_vector([rw[17], rw[18]])[j],
-            M_hdiv[2, j]*as_vector([rw[17], rw[18]])[j],
+            *(as_tensor(M_hdiv[i, j]*as_vector([rw[17], rw[18]])[j], (i,))[n]
+              for n in range(3)),
             # V
             rw[19],
             rw[20],
@@ -326,21 +322,21 @@ def test_apply_single_function_pullbacks_triangle():
             rvdm[0],
             rvdm[1],
             # Vd
-            M_hdiv[0, j]*as_vector([rvdm[2], rvdm[3]])[j],
-            M_hdiv[1, j]*as_vector([rvdm[2], rvdm[3]])[j],
+            *(as_tensor(M_hdiv[i, j]*as_vector([rvdm[2], rvdm[3]])[j], (i,))[n]
+              for n in range(2)),
     ]),
         vcm: as_vector([
             # Vd
-            M_hdiv[0, j]*as_vector([rvcm[0], rvcm[1]])[j],
-            M_hdiv[1, j]*as_vector([rvcm[0], rvcm[1]])[j],
+            *(as_tensor(M_hdiv[i, j]*as_vector([rvcm[0], rvcm[1]])[j], (i,))[n]
+              for n in range(2)),
             # Vc
-            Jinv[i, 0]*as_vector([rvcm[2], rvcm[3]])[i],
-            Jinv[i, 1]*as_vector([rvcm[2], rvcm[3]])[i],
+            *(as_tensor(Jinv[i, j]*as_vector([rvcm[2], rvcm[3]])[i], (j,))[n]
+              for n in range(2)),
     ]),
         tm: as_vector([
             # Vc
-            Jinv[i, 0]*as_vector([rtm[0], rtm[1]])[i],
-            Jinv[i, 1]*as_vector([rtm[0], rtm[1]])[i],
+            *(as_tensor(Jinv[i, j]*as_vector([rtm[0], rtm[1]])[i], (j,))[n]
+              for n in range(2)),
             # T
             rtm[2], rtm[3],
             rtm[4], rtm[5],
@@ -362,11 +358,11 @@ def test_apply_single_function_pullbacks_triangle():
             rw[3], rw[4],
             rw[5], rw[6],
             # Vc
-            Jinv[i, 0]*as_vector([rw[7], rw[8]])[i],
-            Jinv[i, 1]*as_vector([rw[7], rw[8]])[i],
+            *(as_tensor(Jinv[i, j]*as_vector([rw[7], rw[8]])[i], (j,))[n]
+              for n in range(2)),
             # Vd
-            M_hdiv[0, j]*as_vector([rw[9], rw[10]])[j],
-            M_hdiv[1, j]*as_vector([rw[9], rw[10]])[j],
+            *(as_tensor(M_hdiv[i, j]*as_vector([rw[9], rw[10]])[j], (i,))[n]
+              for n in range(2)),
             # V
             rw[11],
             rw[12],

--- a/ufl/algorithms/apply_function_pullbacks.py
+++ b/ufl/algorithms/apply_function_pullbacks.py
@@ -9,6 +9,7 @@
 #
 # Modified by Lizao Li <lzlarryli@gmail.com>, 2016
 
+from itertools import chain, accumulate, repeat
 
 from ufl.log import error
 
@@ -17,8 +18,7 @@ from ufl.corealg.multifunction import MultiFunction, memoized_handler
 from ufl.algorithms.map_integrands import map_integrand_dags
 
 from ufl.classes import (ReferenceValue,
-                         Jacobian, JacobianInverse, JacobianDeterminant,
-                         Index)
+                         Jacobian, JacobianInverse, JacobianDeterminant)
 
 from ufl.tensors import as_tensor, as_vector
 from ufl.utils.sequences import product
@@ -59,184 +59,116 @@ def reshape_to_nested_list(components, shape):
         return [reshape_to_nested_list(components[n * i:n * (i + 1)], shape[1:]) for i in range(shape[0])]
 
 
-def apply_single_function_pullbacks(g):
-    element = g.ufl_element()
+def apply_known_single_pullback(r, element):
+    """Apply pullback with given mapping.
+
+    :arg r: Expression wrapped in ReferenceValue
+    :arg element: The element defining the mapping
+    """
+    # Need to pass in r rather than the physical space thing, because
+    # the latter may be a ListTensor or similar, rather than a
+    # Coefficient/Argument (in the case of mixed elements, see below
+    # in apply_single_function_pullbacks), to which we cannot apply ReferenceValue
     mapping = element.mapping()
-
-    r = ReferenceValue(g)
-    gsh = g.ufl_shape
-    rsh = r.ufl_shape
-
+    domain = r.ufl_domain()
     if mapping == "physical":
-        # TODO: Is this right for immersed things
-        assert gsh == rsh
         return r
-
-    # Shortcut the "identity" case which includes Expression and
-    # Constant from dolfin that may be ill-formed without a domain
-    # (until we get that fixed)
-    if mapping == "identity":
-        assert rsh == gsh
+    elif mapping == "identity":
         return r
-
-    gsize = product(gsh)
-    rsize = product(rsh)
-
-    # Create some geometric objects for reuse
-    domain = g.ufl_domain()
-    J = Jacobian(domain)
-    detJ = JacobianDeterminant(domain)
-    Jinv = JacobianInverse(domain)
-
-    # Create contravariant transform for reuse (note that detJ is the
-    # _signed_ (pseudo-)determinant)
-    transform_hdiv = (1.0 / detJ) * J
-
-    # Shortcut simple cases for a more efficient representation,
-    # including directly Piola-mapped elements and mixed elements of
-    # any combination of affinely mapped elements without symmetries
-    if mapping == "symmetries":
-        fcm = element.flattened_sub_element_mapping()
-        assert gsize >= rsize
-        assert len(fcm) == gsize
-        assert sorted(set(fcm)) == sorted(range(rsize))
-        g_components = [r[fcm[i]] for i in range(gsize)]
-        g_components = reshape_to_nested_list(g_components, gsh)
-        f = as_tensor(g_components)
-        assert f.ufl_shape == g.ufl_shape
-        return f
     elif mapping == "contravariant Piola":
-        assert transform_hdiv.ufl_shape == (gsize, rsize)
-        i, j = indices(2)
-        f = as_vector(transform_hdiv[i, j] * r[j], i)
-        # f = as_tensor(transform_hdiv[i, j]*r[k,j], (k,i)) # FIXME: Handle Vector(Piola) here?
-        assert f.ufl_shape == g.ufl_shape
+        J = Jacobian(domain)
+        detJ = JacobianDeterminant(J)
+        transform = (1.0 / detJ) * J
+        # Apply transform "row-wise" to TensorElement(PiolaMapped, ...)
+        *k, i, j = indices(len(r.ufl_shape) + 1)
+        kj = (*k, j)
+        f = as_tensor(transform[i, j] * r[kj], (*k, i))
         return f
     elif mapping == "covariant Piola":
-        assert Jinv.ufl_shape == (rsize, gsize)
-        i, j = indices(2)
-        f = as_vector(Jinv[j, i] * r[j], i)
-        # f = as_tensor(Jinv[j, i]*r[k,j], (k,i)) # FIXME: Handle Vector(Piola) here?
-        assert f.ufl_shape == g.ufl_shape
-        return f
-    elif mapping == "double covariant Piola":
-        i, j, m, n = indices(4)
-        f = as_tensor(Jinv[m, i] * r[m, n] * Jinv[n, j], (i, j))
-        assert f.ufl_shape == g.ufl_shape
-        return f
-    elif mapping == "double contravariant Piola":
-        i, j, m, n = indices(4)
-        f = as_tensor((1.0 / detJ) * (1.0 / detJ) * J[i, m] * r[m, n] * J[j, n], (i, j))
-        assert f.ufl_shape == g.ufl_shape
+        K = JacobianInverse(domain)
+        # Apply transform "row-wise" to TensorElement(PiolaMapped, ...)
+        *k, i, j = indices(len(r.ufl_shape) + 1)
+        kj = (*k, j)
+        f = as_tensor(K[j, i] * r[kj], (*k, i))
         return f
     elif mapping == "L2 Piola":
-        assert rsh == gsh
+        detJ = JacobianDeterminant(domain)
         return r / detJ
+    elif mapping == "double contravariant Piola":
+        J = Jacobian(domain)
+        detJ = JacobianDeterminant(J)
+        transform = (1.0 / detJ) * J
+        # Apply transform "row-wise" to TensorElement(PiolaMapped, ...)
+        *k, i, j, m, n = indices(len(r.ufl_shape) + 2)
+        kmn = (*k, m, n)
+        f = as_tensor((1.0 / detJ)**2 * J[i, m] * r[kmn] * J[j, n], (*k, i, j))
+        return f
+    elif mapping == "double covariant Piola":
+        K = JacobianInverse(domain)
+        # Apply transform "row-wise" to TensorElement(PiolaMapped, ...)
+        *k, i, j, m, n = indices(len(r.ufl_shape) + 2)
+        kmn = (*k, m, n)
+        f = as_tensor(K[m, i] * r[kmn] * K[n, j], (*k, i, j))
+        return f
+    else:
+        error("Should never be reached!")
 
-    # By placing components in a list and using as_vector at the end,
-    # we're assuming below that both global function g and its
-    # reference value r have vector shape, which is the case for most
-    # elements with the exceptions:
-    # - TensorElements
-    #   - All cases with scalar subelements and without symmetries
-    #     are covered by the shortcut above
-    #     (ONLY IF REFERENCE VALUE SHAPE PRESERVES TENSOR RANK)
-    #   - All cases with scalar subelements and without symmetries are
-    #     covered by the shortcut above
 
-    g_components = [None] * gsize
-    gpos = 0
-    rpos = 0
+def apply_single_function_pullbacks(r, element):
+    """Apply an appropriate pullback to something in physical space
 
-    r = as_vector([r[idx] for idx in numpy.ndindex(r.ufl_shape)])
-    for subelm in sub_elements_with_mappings(element):
-        gm = product(subelm.value_shape())
-        rm = product(subelm.reference_value_shape())
-
-        mp = subelm.mapping()
-        if mp == "identity":
-            assert gm == rm
-            for i in range(gm):
-                g_components[gpos + i] = r[rpos + i]
-
-        elif mp == "symmetries":
-            """
-            tensor_element.value_shape() == (2,2)
-            tensor_element.reference_value_shape() == (3,)
-            tensor_element.symmetry() == { (1,0): (0,1) }
-            tensor_element.component_mapping() == { (0,0): 0, (0,1): 1, (1,0): 1, (1,1): 2 }
-            tensor_element.flattened_component_mapping() == { 0: 0, 1: 1, 2: 1, 3: 2 }
-            """
-            fcm = subelm.flattened_sub_element_mapping()
-            assert gm >= rm
-            assert len(fcm) == gm
-            assert sorted(set(fcm)) == sorted(range(rm))
-            for i in range(gm):
-                g_components[gpos + i] = r[rpos + fcm[i]]
-
-        elif mp == "contravariant Piola":
-            assert transform_hdiv.ufl_shape == (gm, rm)
-            # Get reference value vector corresponding to this subelement:
-            rv = as_vector([r[rpos + k] for k in range(rm)])
-            # Apply transform with IndexSum over j for each row
-            j = Index()
-            for i in range(gm):
-                g_components[gpos + i] = transform_hdiv[i, j] * rv[j]
-
-        elif mp == "covariant Piola":
-            assert Jinv.ufl_shape == (rm, gm)
-            # Get reference value vector corresponding to this subelement:
-            rv = as_vector([r[rpos + k] for k in range(rm)])
-            # Apply transform with IndexSum over j for each row
-            j = Index()
-            for i in range(gm):
-                g_components[gpos + i] = Jinv[j, i] * rv[j]
-
-        elif mp == "double covariant Piola":
-            # components are flatten, map accordingly
-            rv = as_vector([r[rpos + k] for k in range(rm)])
-            (gdim, _) = subelm.value_shape()
-            (rdim, _) = subelm.reference_value_shape()
-            for i in range(gdim):
-                for j in range(gdim):
-                    gv = 0
-                    # int times Index is not allowed. so sum by hand
-                    for m in range(rdim):
-                        for n in range(rdim):
-                            gv += Jinv[m, i] * rv[m * rdim + n] * Jinv[n, j]
-                    g_components[gpos + i * gdim + j] = gv
-
-        elif mp == "double contravariant Piola":
-            # components are flatten, map accordingly
-            rv = as_vector([r[rpos + k] for k in range(rm)])
-            (gdim, _) = subelm.value_shape()
-            (rdim, _) = subelm.reference_value_shape()
-            for i in range(gdim):
-                for j in range(gdim):
-                    gv = 0
-                    # int times Index is not allowed. so sum by hand
-                    for m in range(rdim):
-                        for n in range(rdim):
-                            gv += ((1.0 / detJ) * (1.0 / detJ) *
-                                   J[i, m] * rv[m * rdim + n] * J[j, n])
-                    g_components[gpos + i * gdim + j] = gv
-
-        elif mp == "L2 Piola":
-            assert gm == rm
-            for i in range(gm):
-                g_components[gpos + i] = r[rpos + i] / detJ
-
+    :arg r: An expression wrapped in ReferenceValue.
+    :arg element: The element this expression lives in.
+    :returns: a pulled back expression."""
+    mapping = element.mapping()
+    if r.ufl_shape != element.reference_value_shape():
+        error("Expecting reference space expression with shape '%s', got '%s'" % (element.reference_value_shape(), r.ufl_shape))
+    if mapping in {"physical", "identity",
+                   "contravariant Piola", "covariant Piola",
+                   "double contravariant Piola", "double covariant Piola",
+                   "L2 Piola"}:
+        # Base case in recursion through elements. If the element
+        # advertises a mapping we know how to handle, do that
+        # directly.
+        f = apply_known_single_pullback(r, element)
+        if f.ufl_shape != element.value_shape():
+            error("Expecting pulled back expression with shape '%s', got '%s'" % (element.value_shape(), f.ufl_shape))
+        return f
+    elif mapping in {"symmetries", "undefined"}:
+        # Need to pull back each unique piece of the reference space thing
+        gsh = element.value_shape()
+        rsh = r.ufl_shape
+        if mapping == "symmetries":
+            subelem = element.sub_elements()[0]
+            fcm = element.flattened_sub_element_mapping()
+            offsets = (product(subelem.reference_value_shape()) * i for i in fcm)
+            elements = repeat(subelem)
         else:
-            error("Unknown subelement mapping type %s for element %s." % (mp, str(subelm)))
-
-        gpos += gm
-        rpos += rm
-
-    # Wrap up components in a vector, must return same shape as input
-    # function g
-    f = as_tensor(numpy.asarray(g_components).reshape(gsh))
-    assert f.ufl_shape == g.ufl_shape
-    return f
+            elements = sub_elements_with_mappings(element)
+            # Python >= 3.8 has an initial keyword argument to
+            # accumulate, but 3.7 does not.
+            offsets = chain([0],
+                            accumulate(product(e.reference_value_shape())
+                                       for e in elements))
+        rflat = as_vector([r[idx] for idx in numpy.ndindex(rsh)])
+        g_components = []
+        # For each unique piece in reference space, apply the appropriate pullback
+        for offset, subelem in zip(offsets, elements):
+            sub_rsh = subelem.reference_value_shape()
+            rm = product(sub_rsh)
+            rsub = [rflat[offset + i] for i in range(rm)]
+            rsub = as_tensor(numpy.asarray(rsub).reshape(sub_rsh))
+            rmapped = apply_single_function_pullbacks(rsub, subelem)
+            # Flatten into the pulled back expression for the whole thing
+            g_components.extend([rmapped[idx]
+                                 for idx in numpy.ndindex(rmapped.ufl_shape)])
+        # And reshape appropriately
+        f = as_tensor(numpy.asarray(g_components).reshape(gsh))
+        if f.ufl_shape != element.value_shape():
+            error("Expecting pulled back expression with shape '%s', got '%s'" % (element.value_shape(), f.ufl_shape))
+        return f
+    else:
+        error("Unhandled mapping type '%s'" % mapping)
 
 
 class FunctionPullbackApplier(MultiFunction):
@@ -252,7 +184,9 @@ class FunctionPullbackApplier(MultiFunction):
     def form_argument(self, o):
         # Represent 0-derivatives of form arguments on reference
         # element
-        return apply_single_function_pullbacks(o)
+        f = apply_single_function_pullbacks(ReferenceValue(o), o.ufl_element())
+        assert f.ufl_shape == o.ufl_shape
+        return f
 
 
 def apply_function_pullbacks(expr):

--- a/ufl/finiteelement/mixedelement.py
+++ b/ufl/finiteelement/mixedelement.py
@@ -285,6 +285,7 @@ class VectorElement(MixedElement):
                 error("Cannot infer vector dimension without a cell.")
             dim = cell.geometric_dimension()
 
+        self._mapping = sub_element.mapping()
         # Create list of sub elements for mixed element constructor
         sub_elements = [sub_element] * dim
 
@@ -306,6 +307,9 @@ class VectorElement(MixedElement):
     def reconstruct(self, **kwargs):
         sub_element = self._sub_element.reconstruct(**kwargs)
         return VectorElement(sub_element, dim=len(self.sub_elements()))
+
+    def mapping(self):
+        return self._mapping
 
     def __str__(self):
         "Format as string for pretty printing."
@@ -402,13 +406,11 @@ class TensorElement(MixedElement):
 
         # Compute reference value shape based on symmetries
         if symmetry:
-            # Flatten and subtract symmetries
             reference_value_shape = (product(shape) - len(symmetry),)
             self._mapping = "symmetries"
         else:
-            # Do not flatten if there are no symmetries
             reference_value_shape = shape
-            self._mapping = "identity"
+            self._mapping = sub_element.mapping()
 
         value_shape = value_shape + sub_element.value_shape()
         reference_value_shape = reference_value_shape + sub_element.reference_value_shape()
@@ -428,10 +430,7 @@ class TensorElement(MixedElement):
             repr(sub_element), repr(self._shape), repr(self._symmetry))
 
     def mapping(self):
-        if self._symmetry:
-            return "symmetries"
-        else:
-            return "identity"
+        return self._mapping
 
     def flattened_sub_element_mapping(self):
         return self._flattened_sub_element_mapping

--- a/ufl/indexed.py
+++ b/ufl/indexed.py
@@ -42,6 +42,8 @@ class Indexed(Operator):
             else:
                 fi, fid = (), ()
             return Zero(shape=(), free_indices=fi, index_dimensions=fid)
+        elif expression.ufl_shape == () and multiindex == ():
+            return expression
         else:
             return Operator.__new__(cls)
 
@@ -109,4 +111,8 @@ class Indexed(Operator):
                            self.ufl_operands[1])
 
     def __getitem__(self, key):
+        if key == ():
+            # So that one doesn't have to special case indexing of
+            # expressions without shape.
+            return self
         error("Attempting to index with %s, but object is already indexed: %s" % (ufl_err_str(key), ufl_err_str(self)))

--- a/ufl/tensors.py
+++ b/ufl/tensors.py
@@ -198,7 +198,11 @@ def from_numpy_to_lists(expressions):
     try:
         import numpy
         if isinstance(expressions, numpy.ndarray):
-            expressions = numpy2nestedlists(expressions)
+            if expressions.shape == ():
+                # Unwrap scalar ndarray
+                return expressions.item()
+            else:
+                expressions = numpy2nestedlists(expressions)
     except Exception:
         pass
     return expressions
@@ -231,7 +235,7 @@ def as_tensor(expressions, indices=None):
             expressions = from_numpy_to_lists(expressions)
 
         # Sanity check
-        if not isinstance(expressions, (list, tuple)):
+        if not isinstance(expressions, (list, tuple, Expr)):
             error("Expecting nested list or tuple.")
 
         # Recursive conversion from nested lists to nested ListTensor


### PR DESCRIPTION
Application of pullback to expressions had duplicate code, and didn't handle TensorElements with symmetries unless the sub element was identity-mapped. Refactor and generalise to handle both of those cases.