### PR TITLE
Add function to get the `ufl.Cell` corresponding to a cell's facet

### DIFF
--- a/ufl/cell.py
+++ b/ufl/cell.py
@@ -16,6 +16,7 @@
 import numbers
 import functools
 
+import ufl.cell
 from ufl.log import error
 from ufl.core.ufl_type import attach_operators_from_hash_data
 
@@ -169,6 +170,11 @@ class Cell(AbstractCell):
         # This is used in geometry.py
         fn = cellname2facetname[self.cellname()]
         return num_cell_entities[fn][1]
+
+    def facet_cell(self):
+        "The ufl.Cell representing the facets of self."
+        return ufl.Cell(cellname2facetname[self.cellname()],
+                        self.geometric_dimension())
 
     # --- Special functions for proper object behaviour ---
 

--- a/ufl/cell.py
+++ b/ufl/cell.py
@@ -166,27 +166,17 @@ class Cell(AbstractCell):
 
     # --- Facet properties ---
 
-    def facet_cells(self):
-        "A list of ufl.Cell representing the facets of self."
-        # TODO Replace if with match-case from Python 3.10
-        cell_name = self.cellname()
-        if cell_name == "interval":
-            facet_names = ["vertex"]
-        elif cell_name == "triangle":
-            facet_names = ["interval"]
-        elif cell_name == "quadrilateral":
-            facet_names = ["interval"]
-        elif cell_name == "tetrahedron":
-            facet_names = ["triangle"]
-        elif cell_name == "hexahedron":
-            facet_names = ["quadrilateral"]
-        elif cell_name == "prism":
-            facet_names = ["triangle", "quadrilateral"]
-        else:
-            raise Exception(f"Unknown cell name: {cell_name}")
-
-        return [ufl.Cell(facet_name, self.geometric_dimension())
-                for facet_name in facet_names]
+    def facet_types(self):
+        "A tuple of ufl.Cell representing the facets of self."
+        # TODO Move outside method?
+        facet_type_names = {"interval": ("vertex",),
+                            "triangle": ("interval",),
+                            "quadrilateral": ("interval",),
+                            "tetrahedron": ("triangle",),
+                            "hexahedron": ("quadrilateral",),
+                            "prism": ("triangle", "quadrilateral")}
+        return tuple(ufl.Cell(facet_name, self.geometric_dimension())
+                     for facet_name in facet_type_names[self.cellname()])
 
     # --- Special functions for proper object behaviour ---
 

--- a/ufl/cell.py
+++ b/ufl/cell.py
@@ -96,6 +96,7 @@ cellname2dim = dict((k, len(v) - 1) for k, v in num_cell_entities.items())
 # Mapping from cell name to facet name
 # Note: This is not generalizable to product elements but it's still
 # in use a couple of places.
+# TODO Remove
 cellname2facetname = {"interval": "vertex",
                       "triangle": "interval",
                       "quadrilateral": "interval",
@@ -171,10 +172,27 @@ class Cell(AbstractCell):
         fn = cellname2facetname[self.cellname()]
         return num_cell_entities[fn][1]
 
-    def facet_cell(self):
-        "The ufl.Cell representing the facets of self."
-        return ufl.Cell(cellname2facetname[self.cellname()],
-                        self.geometric_dimension())
+    def facet_cells(self):
+        "A list of ufl.Cell representing the facets of self."
+        # TODO Replace if with match-case from Python 3.10
+        cell_name = self.cellname()
+        if cell_name == "interval":
+            facet_names = ["vertex"]
+        elif cell_name == "triangle":
+            facet_names = ["interval"]
+        elif cell_name == "quadrilateral":
+            facet_names = ["interval"]
+        elif cell_name == "tetrahedron":
+            facet_names = ["triangle"]
+        elif cell_name == "hexahedron":
+            facet_names = ["quadrilateral"]
+        elif cell_name == "prism":
+            facet_names = ["triangle", "quadrilateral"]
+        else:
+            raise Exception(f"Unknown cell name: {cell_name}")
+
+        return [ufl.Cell(facet_name, self.geometric_dimension())
+                for facet_name in facet_names]
 
     # --- Special functions for proper object behaviour ---
 

--- a/ufl/cell.py
+++ b/ufl/cell.py
@@ -166,12 +166,6 @@ class Cell(AbstractCell):
 
     # --- Facet properties ---
 
-    def num_facet_edges(self):
-        "The number of facet edges."
-        # This is used in geometry.py
-        fn = cellname2facetname[self.cellname()]
-        return num_cell_entities[fn][1]
-
     def facet_cells(self):
         "A list of ufl.Cell representing the facets of self."
         # TODO Replace if with match-case from Python 3.10

--- a/ufl/geometry.py
+++ b/ufl/geometry.py
@@ -398,7 +398,13 @@ class ReferenceFacetEdgeVectors(GeometricFacetQuantity):
     @property
     def ufl_shape(self):
         cell = self.ufl_domain().ufl_cell()
-        nfe = cell.num_facet_edges()
+        facet_cells = cell.facet_cells()
+
+        # Raise exception for cells with more than one facet type e.g. prisms
+        if len(facet_cells) > 1:
+            raise Exception(f"Cell type {cell} not supported.")
+
+        nfe = facet_cells[0].num_edges()
         t = cell.topological_dimension()
         return (nfe, t)
 
@@ -470,7 +476,13 @@ class FacetEdgeVectors(GeometricFacetQuantity):
     @property
     def ufl_shape(self):
         cell = self.ufl_domain().ufl_cell()
-        nfe = cell.num_facet_edges()
+        facet_cells = cell.facet_cells()
+
+        # Raise exception for cells with more than one facet type e.g. prisms
+        if len(facet_cells) > 1:
+            raise Exception(f"Cell type {cell} not supported.")
+
+        nfe = facet_cells[0].num_edges()
         g = cell.geometric_dimension()
         return (nfe, g)
 

--- a/ufl/geometry.py
+++ b/ufl/geometry.py
@@ -398,13 +398,13 @@ class ReferenceFacetEdgeVectors(GeometricFacetQuantity):
     @property
     def ufl_shape(self):
         cell = self.ufl_domain().ufl_cell()
-        facet_cells = cell.facet_cells()
+        facet_types = cell.facet_types()
 
         # Raise exception for cells with more than one facet type e.g. prisms
-        if len(facet_cells) > 1:
+        if len(facet_types) > 1:
             raise Exception(f"Cell type {cell} not supported.")
 
-        nfe = facet_cells[0].num_edges()
+        nfe = facet_types[0].num_edges()
         t = cell.topological_dimension()
         return (nfe, t)
 
@@ -476,13 +476,13 @@ class FacetEdgeVectors(GeometricFacetQuantity):
     @property
     def ufl_shape(self):
         cell = self.ufl_domain().ufl_cell()
-        facet_cells = cell.facet_cells()
+        facet_types = cell.facet_types()
 
         # Raise exception for cells with more than one facet type e.g. prisms
-        if len(facet_cells) > 1:
+        if len(facet_types) > 1:
             raise Exception(f"Cell type {cell} not supported.")
 
-        nfe = facet_cells[0].num_edges()
+        nfe = facet_types[0].num_edges()
         g = cell.geometric_dimension()
         return (nfe, g)
 


### PR DESCRIPTION
In some applications, it is useful to get the `ufl.Cell` corresponding to a cell's facets (i.e. for a triangle in 2D space, the facets are `ufl.Cell('interval', 2)`).