### PR TITLE
Add workflow to run DOLFINx and FFCx tests

### DIFF
--- a/.github/workflows/fenicsx-tests.yml
+++ b/.github/workflows/fenicsx-tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install test dependencies
         run: |
           sudo apt-get install -y graphviz libgraphviz-dev ninja-build pkg-config
-          pip3 install pytest-xdist pygraphviz
+          pip3 install pytest-xdist pygraphviz sympy
 
       - name: Install UFL
         run: |

--- a/.github/workflows/fenicsx-tests.yml
+++ b/.github/workflows/fenicsx-tests.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Install test dependencies
         run: |
           sudo apt-get install -y graphviz libgraphviz-dev ninja-build pkg-config
-          pip3 install pytest-xdist pygraphviz sympy
 
       - name: Install UFL
         run: |
@@ -41,7 +40,7 @@ jobs:
       - name: Install FFCx
         run: |
           cd ffcx
-          pip install .
+          pip install .[ci]
       - name: Run FFCx unit tests
         run: python3 -m pytest -n auto ffcx/test
 

--- a/.github/workflows/fenicsx-tests.yml
+++ b/.github/workflows/fenicsx-tests.yml
@@ -1,0 +1,69 @@
+# This workflow will install Basix, FFCx, DOLFINx and run the DOLFINx and FFCx unit tests.
+
+name: FEniCSx integration
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Run DOLFINx tests
+    runs-on: ubuntu-latest
+    container: fenicsproject/test-env:latest-openmpi
+
+    env:
+      CC: clang
+      CXX: clang++
+
+      PETSC_ARCH: linux-gnu-complex-32
+      OMPI_ALLOW_RUN_AS_ROOT: 1
+      OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
+      OMPI_MCA_rmaps_base_oversubscribe: 1
+      OMPI_MCA_plm: isolated
+      OMPI_MCA_btl_vader_single_copy_mechanism: none
+      OMPI_MCA_mpi_yield_when_idle: 1
+      OMPI_MCA_hwloc_base_binding_policy: none
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies (Python)
+        run: |
+          python3 -m pip install --upgrade pip
+
+      - name: Install UFL
+        run: |
+          pip3 install .
+
+      - name: Install Basix
+        run: |
+          python3 -m pip install git+https://github.com/FEniCS/basix.git
+
+      - name: Clone FFCx
+        uses: actions/checkout@v2
+        with:
+          path: ./ffcx
+          repository: FEniCS/ffcx
+          ref: main
+      - name: Install FFCx
+        run: |
+          cd ffcx
+          pip install .
+      - name: Run FFCx unit tests
+        run: python3 -m pytest -n auto ffcs/test
+
+      - name: Clone DOLFINx
+        uses: actions/checkout@v2
+        with:
+          path: ./dolfinx
+          repository: FEniCS/dolfinx
+          ref: main
+      - name: Install DOLFINx
+        run: |
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build -S dolfinx/cpp/
+          cmake --build build
+          cmake --install build
+          pip3 -v install --global-option build --global-option --debug dolfinx/python/
+      - name: Run DOLFINx unit tests
+        run: python3 -m pytest -n auto dolfinx/python/test/unit

--- a/.github/workflows/fenicsx-tests.yml
+++ b/.github/workflows/fenicsx-tests.yml
@@ -22,10 +22,9 @@ jobs:
       - name: Install dependencies (Python)
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install pytest
       - name: Install dependencies (non-Python)
         run: |
-          sudo apt-get install -y graphviz libgraphviz-dev
+          sudo apt-get install -y graphviz libgraphviz-dev ninja-build pkg-config
 
       - name: Install UFL
         run: |

--- a/.github/workflows/fenicsx-tests.yml
+++ b/.github/workflows/fenicsx-tests.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Install dependencies (Python)
         run: |
           python3 -m pip install --upgrade pip
+          python3 -m pip install pygraphviz
 
       - name: Install UFL
         run: |

--- a/.github/workflows/fenicsx-tests.yml
+++ b/.github/workflows/fenicsx-tests.yml
@@ -19,9 +19,6 @@ jobs:
         with:
           python-version: 3.9
 
-      - name: Install dependencies (Python)
-        run: |
-          python3 -m pip install --upgrade pip
       - name: Install dependencies (non-Python)
         run: |
           sudo apt-get install -y graphviz libgraphviz-dev ninja-build pkg-config
@@ -45,7 +42,7 @@ jobs:
           cd ffcx
           pip install .
       - name: Run FFCx unit tests
-        run: python3 -m pytest -n auto ffcx/test
+        run: python3 -m pytest ffcx/test
 
   dolfinx-tests:
     name: Run DOLFINx tests

--- a/.github/workflows/fenicsx-tests.yml
+++ b/.github/workflows/fenicsx-tests.yml
@@ -18,10 +18,13 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
+
       - name: Install dependencies (Python)
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install pygraphviz
+      - name: Install dependencies (non-Python)
+        run: |
+          sudo apt-get install -y graphviz libgraphviz-dev
 
       - name: Install UFL
         run: |

--- a/.github/workflows/fenicsx-tests.yml
+++ b/.github/workflows/fenicsx-tests.yml
@@ -19,11 +19,9 @@ jobs:
         with:
           python-version: 3.9
 
-      - name: Install dependencies (non-Python)
+      - name: Install test dependencies
         run: |
           sudo apt-get install -y graphviz libgraphviz-dev ninja-build pkg-config
-      - name: Install dependencies (non-Python)
-        run: |
           pip3 install pytest-xdist
 
       - name: Install UFL

--- a/.github/workflows/fenicsx-tests.yml
+++ b/.github/workflows/fenicsx-tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install test dependencies
         run: |
           sudo apt-get install -y graphviz libgraphviz-dev ninja-build pkg-config
-          pip3 install pytest-xdist
+          pip3 install pytest-xdist pygraphviz
 
       - name: Install UFL
         run: |

--- a/.github/workflows/fenicsx-tests.yml
+++ b/.github/workflows/fenicsx-tests.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install dependencies (non-Python)
         run: |
           sudo apt-get install -y graphviz libgraphviz-dev ninja-build pkg-config
+      - name: Install dependencies (non-Python)
+        run: |
+          pip3 install pytest-xdist
 
       - name: Install UFL
         run: |
@@ -42,7 +45,7 @@ jobs:
           cd ffcx
           pip install .
       - name: Run FFCx unit tests
-        run: python3 -m pytest ffcx/test
+        run: python3 -m pytest -n auto ffcx/test
 
   dolfinx-tests:
     name: Run DOLFINx tests

--- a/.github/workflows/fenicsx-tests.yml
+++ b/.github/workflows/fenicsx-tests.yml
@@ -8,7 +8,42 @@ on:
       - main
 
 jobs:
-  build:
+  ffcx-tests:
+    name: Run FFCx tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install dependencies (Python)
+        run: |
+          python3 -m pip install --upgrade pip
+
+      - name: Install UFL
+        run: |
+          pip3 install .
+
+      - name: Install Basix
+        run: |
+          python3 -m pip install git+https://github.com/FEniCS/basix.git
+
+      - name: Clone FFCx
+        uses: actions/checkout@v2
+        with:
+          path: ./ffcx
+          repository: FEniCS/ffcx
+          ref: main
+      - name: Install FFCx
+        run: |
+          cd ffcx
+          pip install .
+      - name: Run FFCx unit tests
+        run: python3 -m pytest -n auto ffcx/test
+
+  dolfinx-tests:
     name: Run DOLFINx tests
     runs-on: ubuntu-latest
     container: fenicsproject/test-env:latest-openmpi
@@ -36,22 +71,10 @@ jobs:
         run: |
           pip3 install .
 
-      - name: Install Basix
+      - name: Install Basix and FFCx
         run: |
           python3 -m pip install git+https://github.com/FEniCS/basix.git
-
-      - name: Clone FFCx
-        uses: actions/checkout@v2
-        with:
-          path: ./ffcx
-          repository: FEniCS/ffcx
-          ref: main
-      - name: Install FFCx
-        run: |
-          cd ffcx
-          pip install .
-      - name: Run FFCx unit tests
-        run: python3 -m pytest -n auto ffcx/test
+          python3 -m pip install git+https://github.com/FEniCS/ffcx.git
 
       - name: Clone DOLFINx
         uses: actions/checkout@v2

--- a/.github/workflows/fenicsx-tests.yml
+++ b/.github/workflows/fenicsx-tests.yml
@@ -51,7 +51,7 @@ jobs:
           cd ffcx
           pip install .
       - name: Run FFCx unit tests
-        run: python3 -m pytest -n auto ffcs/test
+        run: python3 -m pytest -n auto ffcx/test
 
       - name: Clone DOLFINx
         uses: actions/checkout@v2

--- a/.github/workflows/fenicsx-tests.yml
+++ b/.github/workflows/fenicsx-tests.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Install dependencies (Python)
         run: |
           python3 -m pip install --upgrade pip
+          python3 -m pip install pytest
       - name: Install dependencies (non-Python)
         run: |
           sudo apt-get install -y graphviz libgraphviz-dev


### PR DESCRIPTION
When a PR is opened, the FFCx and DOLFINx tests will be run using the updated UFL.

This will make is easier to catch when changes to UFL might require changes to FFCx and DOLFINx.

I think it would be sensible to add a similar CI for Firedrake at some point, if someone from Firedrake wants to set something similar up.