### PR TITLE
Group integrals with common integrand in IntegralData

### DIFF
--- a/.github/workflows/fenicsx-tests.yml
+++ b/.github/workflows/fenicsx-tests.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           path: ./ffcx
           repository: FEniCS/ffcx
-          ref: main
+          ref: dokken/group_integrals
       - name: Install FFCx
         run: |
           cd ffcx
@@ -82,7 +82,7 @@ jobs:
         with:
           path: ./dolfinx
           repository: FEniCS/dolfinx
-          ref: main
+          ref: dokken/group_integrals
       - name: Install DOLFINx
         run: |
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build -S dolfinx/cpp/

--- a/test/test_domains.py
+++ b/test/test_domains.py
@@ -4,6 +4,7 @@
 Tests of domain language and attaching domains to forms.
 """
 
+from mockobjects import MockMesh, MockMeshFunction
 import pytest
 
 from ufl import *
@@ -12,8 +13,6 @@ from ufl.algorithms import compute_form_data
 
 all_cells = (interval, triangle, tetrahedron,
              quadrilateral, hexahedron)
-
-from mockobjects import MockMesh, MockMeshFunction
 
 
 def test_construct_domains_from_cells():
@@ -198,7 +197,8 @@ def test_everywhere_integrals_with_backwards_compatibility():
 
     # Check some integral data
     assert ida.integral_type == "cell"
-    assert ida.subdomain_id == "otherwise"
+    assert(len(ida.subdomain_id) == 1)
+    assert ida.subdomain_id[0] == "otherwise"
     assert ida.metadata == {}
 
     # Integrands are not equal because of renumbering
@@ -366,10 +366,10 @@ def xtest_form_domain_model():  # Old sketch, not working
     # domains and regions to be part of their integrands
     dxb = dx('DB')   # Get Mesh by name
     dxbl = dx(Region(DB, (1, 4), 'DBL2'))
-              # Provide a region with different name but same subdomain ids as
-              # DBL
+    # Provide a region with different name but same subdomain ids as
+    # DBL
     dxbr = dx((1, 4))
-              # Assume unique Mesh and provide subdomain ids explicitly
+    # Assume unique Mesh and provide subdomain ids explicitly
 
     # Not checking measure objects in detail, as long as
     # they carry information to construct integrals below
@@ -466,8 +466,8 @@ def xtest_subdomain_stuff():  # Old sketch, not working
 
     # Disjunctified by UFL:
     alonly = dot(ul, vl) * dx(D1)
-                 # integral_1 knows that only subelement VL is active
+    # integral_1 knows that only subelement VL is active
     am = (dot(ul, vl) + ur * vr) * dx(D2)
-          # integral_2 knows that both subelements are active
+    # integral_2 knows that both subelements are active
     aronly = ur * vr * \
         dx(D3)  # integral_3 knows that only subelement VR is active

--- a/ufl/algorithms/compute_form_data.py
+++ b/ufl/algorithms/compute_form_data.py
@@ -106,11 +106,9 @@ def _compute_max_subdomain_ids(integral_data):
     for itg_data in integral_data:
         it = itg_data.integral_type
         for integral in itg_data.integrals:
-            si = max(integral.subdomain_id())
-            if isinstance(si, int):
-                newmax = si + 1
-            else:
-                newmax = 0
+            # Convert string for default integral to -1
+            sids = (-1 if isinstance(si, str) else si for si in integral.subdomain_id())
+            newmax = max(sids) + 1
             prevmax = max_subdomain_ids.get(it, 0)
             max_subdomain_ids[it] = max(prevmax, newmax)
     return max_subdomain_ids
@@ -328,6 +326,7 @@ def compute_form_data(form,
     # --- Group integrals into IntegralData objects
     # Most of the heavy lifting is done above in group_form_integrals.
     self.integral_data = build_integral_data(form.integrals())
+
     # --- Create replacements for arguments and coefficients
 
     # Figure out which form coefficients each integral should enable

--- a/ufl/algorithms/compute_form_data.py
+++ b/ufl/algorithms/compute_form_data.py
@@ -105,13 +105,14 @@ def _compute_max_subdomain_ids(integral_data):
     max_subdomain_ids = {}
     for itg_data in integral_data:
         it = itg_data.integral_type
-        si = itg_data.subdomain_id
-        if isinstance(si, int):
-            newmax = si + 1
-        else:
-            newmax = 0
-        prevmax = max_subdomain_ids.get(it, 0)
-        max_subdomain_ids[it] = max(prevmax, newmax)
+        for integral in itg_data.integrals:
+            si = max(integral.subdomain_id())
+            if isinstance(si, int):
+                newmax = si + 1
+            else:
+                newmax = 0
+            prevmax = max_subdomain_ids.get(it, 0)
+            max_subdomain_ids[it] = max(prevmax, newmax)
     return max_subdomain_ids
 
 
@@ -327,7 +328,6 @@ def compute_form_data(form,
     # --- Group integrals into IntegralData objects
     # Most of the heavy lifting is done above in group_form_integrals.
     self.integral_data = build_integral_data(form.integrals())
-
     # --- Create replacements for arguments and coefficients
 
     # Figure out which form coefficients each integral should enable

--- a/ufl/algorithms/domain_analysis.py
+++ b/ufl/algorithms/domain_analysis.py
@@ -13,6 +13,7 @@ import ufl
 from ufl.log import error
 from ufl.integral import Integral
 from ufl.form import Form
+from ufl.protocols import id_or_none
 from ufl.sorting import cmp_expr, sorted_expr
 from ufl.utils.sorting import canonicalize_metadata, sorted_by_key
 from ufl.algorithms.coordinate_derivative_helpers import attach_coordinate_derivatives, strip_coordinate_derivatives
@@ -246,16 +247,29 @@ def build_integral_data(integrals):
     """
     itgs = defaultdict(list)
 
+    # --- Merge integral data that has the same integrals,
+    unique_integrals = defaultdict(tuple)
+    metadata_table = defaultdict(dict)
     for integral in integrals:
-        domain = integral.ufl_domain()
+        integrand = integral.integrand()
         integral_type = integral.integral_type()
+        ufl_domain = integral.ufl_domain()
+        metadata = integral.metadata()
+        meta_hash = hash(canonicalize_metadata(metadata))
         subdomain_id = integral.subdomain_id()
+        subdomain_data = id_or_none(integral.subdomain_data())
         if subdomain_id == "everywhere":
             raise ValueError("'everywhere' not a valid subdomain id.  Did you forget to call group_form_integrals?")
+        unique_integrals[(integral_type, ufl_domain, meta_hash, integrand, subdomain_data)] += (subdomain_id,)
+        metadata_table[(integral_type, ufl_domain, meta_hash, integrand, subdomain_data)] = metadata
+
+    for integral_data, subdomain_ids in unique_integrals.items():
+        (integral_type, ufl_domain, metadata, integrand, subdomain_data) = integral_data
+
+        integral = Integral(integrand, integral_type, ufl_domain, subdomain_ids, metadata_table[integral_data], subdomain_data)
         # Group for integral data (One integral data object for all
-        # integrals with same domain, itype, subdomain_id (but
-        # possibly different metadata).
-        itgs[(domain, integral_type, subdomain_id)].append(integral)
+        # integrals with same domain, itype, (but possibly different metadata).
+        itgs[(ufl_domain, integral_type, subdomain_ids)].append(integral)
 
     # Build list with canonical ordering, iteration over dicts
     # is not deterministic across python versions
@@ -277,8 +291,7 @@ def group_form_integrals(form, domains, do_append_everywhere_integrals=True):
     :returns: A new :class:`~.Form` with gathered integrands.
     """
     # Group integrals by domain and type
-    integrals_by_domain_and_type = \
-        group_integrals_by_domain_and_type(form.integrals(), domains)
+    integrals_by_domain_and_type = group_integrals_by_domain_and_type(form.integrals(), domains)
 
     integrals = []
     for domain in domains:
@@ -292,8 +305,7 @@ def group_form_integrals(form, domains, do_append_everywhere_integrals=True):
             #   f*dx((1,2)) + g*dx((2,3)) -> f*dx(1) + (f+g)*dx(2) + g*dx(3)
             # (note: before this call, 'everywhere' is a valid subdomain_id,
             # and after this call, 'otherwise' is a valid subdomain_id)
-            single_subdomain_integrals = \
-                rearrange_integrals_by_single_subdomains(ddt_integrals, do_append_everywhere_integrals)
+            single_subdomain_integrals = rearrange_integrals_by_single_subdomains(ddt_integrals, do_append_everywhere_integrals)
 
             for subdomain_id, ss_integrals in sorted_by_key(single_subdomain_integrals):
 
@@ -322,8 +334,7 @@ def group_form_integrals(form, domains, do_append_everywhere_integrals=True):
 
                     # Accumulate integrands of integrals that share the
                     # same compiler data
-                    integrands_and_cds = \
-                        accumulate_integrands_with_same_metadata(samecd_integrals[1])
+                    integrands_and_cds = accumulate_integrands_with_same_metadata(samecd_integrals[1])
 
                     for integrand, metadata in integrands_and_cds:
                         integral = Integral(integrand, integral_type, domain,


### PR DESCRIPTION
MWE:
```
from ufl import FiniteElement, TrialFunction, TestFunction, dx, Mesh, VectorElement, triangle, FunctionSpace, inner, grad
import ufl.algorithms
import ufl.classes
mesh = Mesh(VectorElement("Lagrange", triangle, 1))
V = FunctionSpace(mesh, FiniteElement("Lagrange", triangle, 1))
u = TrialFunction(V)
v = TestFunction(V)
a = inner(u, v)*dx((1, 2, 3)) + inner(grad(u), grad(v))*dx(2) + inner(u, v)*dx

form_data = ufl.algorithms.compute_form_data(
    a,
    do_apply_function_pullbacks=True,
    do_apply_integral_scaling=True,
    do_apply_geometry_lowering=True,
    preserve_geometry_types=(ufl.classes.Jacobian,),
    do_apply_restrictions=True,
    do_append_everywhere_integrals=False)
for integral in form_data.integral_data:
    print(str(integral))
```
On this branch, we get two `IntegralData`, one for `inner(u,v)*dx((1,3,"everywhere"))` and one for `(inner(u,v) + inner(grad(u), grad(v)))*dx((2,))`.
On main one would get four integral datas; `inner(u,v)*dx(i)` for `i=1,3,"everywhere"` and `(inner(u,v) + inner(grad(u), grad(v)))*dx((2,))`.

This is relevant when loading complex meshes with hundreds of subdomain_ids, where a tuple of subdomain ids is used to indicate a union of domains to integrate over. This would cause the compilers in `Firedrake` and `DOLFINx` to generate hundreds of duplicate kernels, which makes the generated code unreadable and slow to generate.