### PR TITLE
Signature computation speedup

### DIFF
--- a/ufl/algorithms/signature.py
+++ b/ufl/algorithms/signature.py
@@ -122,7 +122,7 @@ def compute_expression_signature(expr, renumbering):  # FIXME: Fix callers
 
     # Pass it through a seriously overkill hashing algorithm
     # (should we use sha1 instead?)
-    return hashlib.sha512(expression_hashdata).hexdigest()
+    return expression_hashdata.hex()
 
 
 def compute_form_signature(form, renumbering):  # FIXME: Fix callers

--- a/ufl/algorithms/signature.py
+++ b/ufl/algorithms/signature.py
@@ -14,7 +14,7 @@ from ufl.classes import (Label,
                          GeometricQuantity, ConstantValue, Constant,
                          ExprList, ExprMapping)
 from ufl.log import error
-from ufl.corealg.traversal import traverse_unique_terminals, pre_traversal
+from ufl.corealg.traversal import traverse_unique_terminals, unique_pre_traversal
 from ufl.algorithms.domain_analysis import canonicalize_metadata
 
 
@@ -98,7 +98,7 @@ def compute_expression_hashdata(expression, terminal_hashdata):
     # notation, i.e. we store the equivalent of '+ * a b * c d' for
     # the expression (a*b)+(c*d)
     expression_hashdata = []
-    for expr in pre_traversal(expression):
+    for expr in unique_pre_traversal(expression):
         if expr._ufl_is_terminal_:
             data = terminal_hashdata[expr]
         else:

--- a/ufl/algorithms/signature.py
+++ b/ufl/algorithms/signature.py
@@ -94,16 +94,19 @@ def compute_terminal_hashdata(expressions, renumbering):
 
 
 def compute_expression_hashdata(expression, terminal_hashdata):
-    # The hashdata computed here can be interpreted as prefix operator
-    # notation, i.e. we store the equivalent of '+ * a b * c d' for
-    # the expression (a*b)+(c*d)
     expression_hashdata = []
+
     for expr in unique_pre_traversal(expression):
+        # Visit each node only once, but store all its operands
         if expr._ufl_is_terminal_:
-            data = terminal_hashdata[expr]
+            expression_hashdata.append(terminal_hashdata[expr])
         else:
-            data = expr._ufl_typecode_  # TODO: Use expr._ufl_signature_data_()? More extensible, but more overhead.
-        expression_hashdata.append(data)
+            expression_hashdata.append(expr._ufl_typecode_)
+            for op in expr.ufl_operands:
+                if op._ufl_is_terminal_:
+                    expression_hashdata.append(terminal_hashdata[op])
+                else:
+                    expression_hashdata.append(op._ufl_typecode_)
 
     return expression_hashdata
 

--- a/ufl/algorithms/signature.py
+++ b/ufl/algorithms/signature.py
@@ -104,9 +104,7 @@ def compute_expression_hashdata(expression, terminal_hashdata):
         else:
             data = expr._ufl_typecode_  # TODO: Use expr._ufl_signature_data_()? More extensible, but more overhead.
         expression_hashdata.append(data)
-    # Oneliner: TODO: Benchmark, maybe use a generator?
-    # expression_hashdata = [(terminal_hashdata[expr] if expr._ufl_is_terminal_ else expr._ufl_typecode_)
-    #                       for expr in pre_traversal(expression)]
+
     return expression_hashdata
 
 


### PR DESCRIPTION
EDIT: See comments for updates. Current solution is based on unique post traversal and computing hash at each node during the traversal.

For complicated UFL forms signature computation easily dominates JIT compilation, often even assembly times. Expression signatures are fetched e.g. in FFCx for disk caching - which contributes a unique hash into binary file name.

~This PR changes `pre_traversal` to `unique_pre_traversal` for expression hashdata, which has significant 700x speedup in some cases (see cProfiler images below). Additionally, operands (their ufl typecode) are added to the generated hashdata to make it unique.~
