### PR TITLE
Editable installs with --user has been fixed with `pip.__version__`>=21.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,11 @@
 import setuptools
-
-# Can be removed when pip editable user installs are fixed
-# https://github.com/pypa/pip/issues/7953
-import site
 import sys
-site.ENABLE_USER_SITE = "--user" in sys.argv[1:]
+
+
+if sys.version_info < (3, 10):
+    # Can be removed when pip editable user installs are fixed
+    # https://github.com/pypa/pip/issues/7953
+    import site
+    site.ENABLE_USER_SITE = "--user" in sys.argv[1:]
 
 setuptools.setup()

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,7 @@ try:
 
     from packaging import version
     if version.parse(pip.__version__) < version.parse("21.3"):
-        # Can be removed when pip editable user installs are fixed
-        # https://github.com/pypa/pip/issues/7953
+        # Issue with older version of pip https://github.com/pypa/pip/issues/7953
         import site
         import sys
         site.ENABLE_USER_SITE = "--user" in sys.argv[1:]

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,17 @@
 import setuptools
-import sys
 
+try:
+    import pip
 
-if sys.version_info < (3, 10):
-    # Can be removed when pip editable user installs are fixed
-    # https://github.com/pypa/pip/issues/7953
-    import site
-    site.ENABLE_USER_SITE = "--user" in sys.argv[1:]
+    from packaging import version
+    if version.parse(pip.__version__) < version.parse("21.3"):
+        # Can be removed when pip editable user installs are fixed
+        # https://github.com/pypa/pip/issues/7953
+        import site
+        import sys
+        site.ENABLE_USER_SITE = "--user" in sys.argv[1:]
+
+except ImportError:
+    pass
 
 setuptools.setup()


### PR DESCRIPTION
Using the `dolfinx/dev-env` container (ubuntu 22.04 with python3.10), the lines fixing the `-e --user` installs with pip3 throws:
```bash
Using pip 22.1.1 from /usr/local/lib/python3.10/dist-packages/pip (python 3.10)
Obtaining file:///root/shared/ufl
  Running command pip subprocess to install build dependencies
  Collecting setuptools>=58
    Using cached setuptools-62.3.2-py3-none-any.whl (1.2 MB)
  Collecting wheel
    Using cached wheel-0.37.1-py2.py3-none-any.whl (35 kB)
  Installing collected packages: wheel, setuptools
  Successfully installed setuptools-62.3.2 wheel-0.37.1
  WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
  Installing build dependencies ... done
  Running command Checking if build backend supports build_editable
  Checking if build backend supports build_editable ... done
  Running command Getting requirements to build wheel
  Getting requirements to build wheel ... done
  Running command Preparing metadata (pyproject.toml)
  running dist_info
  creating /tmp/pip-modern-metadata-gowbeoid/fenics_ufl.egg-info
  writing /tmp/pip-modern-metadata-gowbeoid/fenics_ufl.egg-info/PKG-INFO
  writing dependency_links to /tmp/pip-modern-metadata-gowbeoid/fenics_ufl.egg-info/dependency_links.txt
  writing requirements to /tmp/pip-modern-metadata-gowbeoid/fenics_ufl.egg-info/requires.txt
  writing top-level names to /tmp/pip-modern-metadata-gowbeoid/fenics_ufl.egg-info/top_level.txt
  writing manifest file '/tmp/pip-modern-metadata-gowbeoid/fenics_ufl.egg-info/SOURCES.txt'
  reading manifest file '/tmp/pip-modern-metadata-gowbeoid/fenics_ufl.egg-info/SOURCES.txt'
  reading manifest template 'MANIFEST.in'
  warning: no previously-included files matching '__pycache__' found anywhere in distribution
  adding license file 'COPYING'
  adding license file 'COPYING.LESSER'
  adding license file 'AUTHORS'
  writing manifest file '/tmp/pip-modern-metadata-gowbeoid/fenics_ufl.egg-info/SOURCES.txt'
  creating '/tmp/pip-modern-metadata-gowbeoid/fenics_ufl.dist-info'
  adding license file "COPYING" (matched pattern "COPYING*")
  adding license file "COPYING.LESSER" (matched pattern "COPYING*")
  adding license file "AUTHORS" (matched pattern "AUTHORS*")
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: numpy in /usr/lib/python3/dist-packages (from fenics-ufl==2022.2.0.dev0) (1.21.5)
Installing collected packages: fenics-ufl
  Running setup.py develop for fenics-ufl
    Running command python setup.py develop
    running develop
    /usr/lib/python3/dist-packages/setuptools/command/easy_install.py:158: EasyInstallDeprecationWarning: easy_install command is deprecated. Use build and pip and other standards-based tools.
      warnings.warn(
    Traceback (most recent call last):
      File "<string>", line 2, in <module>
      File "<pip-setuptools-caller>", line 34, in <module>
      File "/root/shared/ufl/setup.py", line 11, in <module>
        setuptools.setup()
      File "/usr/lib/python3/dist-packages/setuptools/__init__.py", line 153, in setup
        return distutils.core.setup(**attrs)
      File "/usr/lib/python3/dist-packages/setuptools/_distutils/core.py", line 148, in setup
        return run_commands(dist)
      File "/usr/lib/python3/dist-packages/setuptools/_distutils/core.py", line 163, in run_commands
        dist.run_commands()
      File "/usr/lib/python3/dist-packages/setuptools/_distutils/dist.py", line 967, in run_commands
        self.run_command(cmd)
      File "/usr/lib/python3/dist-packages/setuptools/_distutils/dist.py", line 985, in run_command
        cmd_obj.ensure_finalized()
      File "/usr/lib/python3/dist-packages/setuptools/_distutils/cmd.py", line 107, in ensure_finalized
        self.finalize_options()
      File "/usr/lib/python3/dist-packages/setuptools/command/develop.py", line 52, in finalize_options
        easy_install.finalize_options(self)
      File "/usr/lib/python3/dist-packages/setuptools/command/easy_install.py", line 270, in finalize_options
        self._fix_install_dir_for_user_site()
      File "/usr/lib/python3/dist-packages/setuptools/command/easy_install.py", line 400, in _fix_install_dir_for_user_site
        self.select_scheme(scheme_name)
      File "/usr/lib/python3/dist-packages/setuptools/command/easy_install.py", line 741, in select_scheme
        scheme = INSTALL_SCHEMES[name]
    KeyError: 'unix_user'
    error: subprocess-exited-with-error
    
    × python setup.py develop did not run successfully.
    │ exit code: 1
    ╰─> See above for output.
    
    note: This error originates from a subprocess, and is likely not a problem with pip.
    full command: /usr/bin/python3 -c '
    exec(compile('"'"''"'"''"'"'
    # This is <pip-setuptools-caller> -- a caller that pip uses to run setup.py
    #
    # - It imports setuptools before invoking setup.py, to enable projects that directly
    #   import from `distutils.core` to work with newer packaging standards.
    # - It provides a clear error message when setuptools is not installed.
    # - It sets `sys.argv[0]` to the underlying `setup.py`, when invoking `setup.py` so
    #   setuptools doesn'"'"'t think the script is `-c`. This avoids the following warning:
    #     manifest_maker: standard file '"'"'-c'"'"' not found".
    # - It generates a shim setup.py, for handling setup.cfg-only projects.
    import os, sys, tokenize
    
    try:
        import setuptools
    except ImportError as error:
        print(
            "ERROR: Can not execute `setup.py` since setuptools is not available in "
            "the build environment.",
            file=sys.stderr,
        )
        sys.exit(1)
    
    __file__ = %r
    sys.argv[0] = __file__
    
    if os.path.exists(__file__):
        filename = __file__
        with tokenize.open(__file__) as f:
            setup_py_code = f.read()
    else:
        filename = "<auto-generated setuptools caller>"
        setup_py_code = "from setuptools import setup; setup()"
    
    exec(compile(setup_py_code, filename, "exec"))
    '"'"''"'"''"'"' % ('"'"'/root/shared/ufl/setup.py'"'"',), "<pip-setuptools-caller>", "exec"))' develop --no-deps --user --prefix=
    cwd: /root/shared/ufl/
error: subprocess-exited-with-error

× python setup.py develop did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```
Running without these lines works with no error thrown.