### PR TITLE
Add `is_fully_continuous` function to finite element

### DIFF
--- a/.github/workflows/fenicsx-tests.yml
+++ b/.github/workflows/fenicsx-tests.yml
@@ -11,6 +11,9 @@ jobs:
   ffcx-tests:
     name: Run FFCx tests
     runs-on: ubuntu-latest
+    env:
+      CC: gcc-10
+      CXX: g++-10
 
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ test/.pytest_cache
 *.egg-info
 dist/
 release/
+
+.*.swp

--- a/ufl/algorithms/apply_restrictions.py
+++ b/ufl/algorithms/apply_restrictions.py
@@ -131,9 +131,7 @@ class RestrictionPropagator(MultiFunction):
         e = o.ufl_element()
         d = e.degree()
         f = e.family()
-        # TODO: Move this choice to the element class?
-        continuous_families = ["Lagrange", "Q", "S"]
-        if (f in continuous_families and d > 0) or f == "Real":
+        if e.is_fully_continuous():
             # If the coefficient _value_ is _fully_ continuous
             return self._default_restricted(o)  # Must still be computed from one of the sides, we just don't care which
         else:

--- a/ufl/algorithms/apply_restrictions.py
+++ b/ufl/algorithms/apply_restrictions.py
@@ -129,7 +129,7 @@ class RestrictionPropagator(MultiFunction):
     def coefficient(self, o):
         "Allow coefficients to be unrestricted (apply default if so) if the values are fully continuous across the facet."
         e = o.ufl_element()
-        if e.is_fully_continuous():
+        if e.is_continuous():
             # If the coefficient _value_ is _fully_ continuous
             return self._default_restricted(o)  # Must still be computed from one of the sides, we just don't care which
         else:

--- a/ufl/algorithms/apply_restrictions.py
+++ b/ufl/algorithms/apply_restrictions.py
@@ -129,8 +129,6 @@ class RestrictionPropagator(MultiFunction):
     def coefficient(self, o):
         "Allow coefficients to be unrestricted (apply default if so) if the values are fully continuous across the facet."
         e = o.ufl_element()
-        d = e.degree()
-        f = e.family()
         if e.is_fully_continuous():
             # If the coefficient _value_ is _fully_ continuous
             return self._default_restricted(o)  # Must still be computed from one of the sides, we just don't care which

--- a/ufl/algorithms/apply_restrictions.py
+++ b/ufl/algorithms/apply_restrictions.py
@@ -129,6 +129,8 @@ class RestrictionPropagator(MultiFunction):
     def coefficient(self, o):
         "Allow coefficients to be unrestricted (apply default if so) if the values are fully continuous across the facet."
         e = o.ufl_element()
+        print(e)
+        print(e.is_fully_continuous())
         if e.is_fully_continuous():
             # If the coefficient _value_ is _fully_ continuous
             return self._default_restricted(o)  # Must still be computed from one of the sides, we just don't care which

--- a/ufl/algorithms/apply_restrictions.py
+++ b/ufl/algorithms/apply_restrictions.py
@@ -129,8 +129,6 @@ class RestrictionPropagator(MultiFunction):
     def coefficient(self, o):
         "Allow coefficients to be unrestricted (apply default if so) if the values are fully continuous across the facet."
         e = o.ufl_element()
-        print(e)
-        print(e.is_fully_continuous())
         if e.is_fully_continuous():
             # If the coefficient _value_ is _fully_ continuous
             return self._default_restricted(o)  # Must still be computed from one of the sides, we just don't care which

--- a/ufl/finiteelement/brokenelement.py
+++ b/ufl/finiteelement/brokenelement.py
@@ -37,3 +37,7 @@ class BrokenElement(FiniteElementBase):
     def shortstr(self):
         "Format as string for pretty printing."
         return "BrokenElement(%s)" % str(self._element.shortstr())
+
+    def is_fully_continuous(self):
+        """Return true if the values of this element's basis functions are continuous between elements."""
+        return False

--- a/ufl/finiteelement/brokenelement.py
+++ b/ufl/finiteelement/brokenelement.py
@@ -38,6 +38,6 @@ class BrokenElement(FiniteElementBase):
         "Format as string for pretty printing."
         return "BrokenElement(%s)" % str(self._element.shortstr())
 
-    def is_fully_continuous(self):
+    def is_continuous(self):
         """Return true if the values of this element's basis functions are continuous between elements."""
         return False

--- a/ufl/finiteelement/enrichedelement.py
+++ b/ufl/finiteelement/enrichedelement.py
@@ -88,7 +88,7 @@ class EnrichedElementBase(FiniteElementBase):
     def reconstruct(self, **kwargs):
         return type(self)(*[e.reconstruct(**kwargs) for e in self._elements])
 
-    def is_fully_continuous(self):
+    def is_continuous(self):
         """Return true if the values of this element's basis functions are continuous between elements."""
         return all(e.is_fully_continuous() for e in self._sub_elements)
 

--- a/ufl/finiteelement/enrichedelement.py
+++ b/ufl/finiteelement/enrichedelement.py
@@ -88,6 +88,13 @@ class EnrichedElementBase(FiniteElementBase):
     def reconstruct(self, **kwargs):
         return type(self)(*[e.reconstruct(**kwargs) for e in self._elements])
 
+    def is_fully_continuous(self):
+        """Return true if the values of this element's basis functions are continuous between elements."""
+        for e in self._elements:
+            if not e.is_fully_continuous():
+                return False
+        return True
+
 
 class EnrichedElement(EnrichedElementBase):
     """The vector sum of several finite element spaces:

--- a/ufl/finiteelement/enrichedelement.py
+++ b/ufl/finiteelement/enrichedelement.py
@@ -90,10 +90,7 @@ class EnrichedElementBase(FiniteElementBase):
 
     def is_fully_continuous(self):
         """Return true if the values of this element's basis functions are continuous between elements."""
-        for e in self._elements:
-            if not e.is_fully_continuous():
-                return False
-        return True
+        return all(e.is_fully_continuous() for e in self._sub_elements)
 
 
 class EnrichedElement(EnrichedElementBase):

--- a/ufl/finiteelement/finiteelement.py
+++ b/ufl/finiteelement/finiteelement.py
@@ -242,4 +242,4 @@ class FiniteElement(FiniteElementBase):
         """Return true if the values of this element's basis functions are continuous between elements."""
         if self.family() == "Real":
             return True
-        return self._sobolev_space in H1
+        return self in H1

--- a/ufl/finiteelement/finiteelement.py
+++ b/ufl/finiteelement/finiteelement.py
@@ -238,7 +238,7 @@ class FiniteElement(FiniteElementBase):
                 self.quadrature_scheme(),
                 self.variant())
 
-    def is_fully_continuous(self):
+    def is_continuous(self):
         """Return true if the values of this element's basis functions are continuous between elements."""
         if self.family() == "Real":
             return True

--- a/ufl/finiteelement/finiteelement.py
+++ b/ufl/finiteelement/finiteelement.py
@@ -19,6 +19,7 @@ from ufl.cell import as_cell
 from ufl.cell import TensorProductCell
 from ufl.finiteelement.elementlist import canonical_element_description, simplices
 from ufl.finiteelement.finiteelementbase import FiniteElementBase
+from ufl.sobolevspace import H1, H2
 
 
 class FiniteElement(FiniteElementBase):
@@ -236,3 +237,7 @@ class FiniteElement(FiniteElementBase):
                 None,
                 self.quadrature_scheme(),
                 self.variant())
+
+    def is_fully_continuous(self):
+        """Return true if the values of this element's basis functions are continuous between elements."""
+        return self._sobolev_space in [H1, H2]

--- a/ufl/finiteelement/finiteelement.py
+++ b/ufl/finiteelement/finiteelement.py
@@ -240,4 +240,6 @@ class FiniteElement(FiniteElementBase):
 
     def is_fully_continuous(self):
         """Return true if the values of this element's basis functions are continuous between elements."""
+        if self.family() == "Real":
+            return True
         return self._sobolev_space in [H1, H2]

--- a/ufl/finiteelement/finiteelement.py
+++ b/ufl/finiteelement/finiteelement.py
@@ -19,7 +19,7 @@ from ufl.cell import as_cell
 from ufl.cell import TensorProductCell
 from ufl.finiteelement.elementlist import canonical_element_description, simplices
 from ufl.finiteelement.finiteelementbase import FiniteElementBase
-from ufl.sobolevspace import H1, H2
+from ufl.sobolevspace import H1
 
 
 class FiniteElement(FiniteElementBase):
@@ -242,4 +242,4 @@ class FiniteElement(FiniteElementBase):
         """Return true if the values of this element's basis functions are continuous between elements."""
         if self.family() == "Real":
             return True
-        return self._sobolev_space in [H1, H2]
+        return self._sobolev_space in H1

--- a/ufl/finiteelement/finiteelementbase.py
+++ b/ufl/finiteelement/finiteelementbase.py
@@ -213,3 +213,11 @@ class FiniteElementBase(object):
             from ufl.finiteelement import RestrictedElement
             return RestrictedElement(self, index)
         return NotImplemented
+
+    def is_fully_continuous(self):
+        """Return true if the values of this element's basis functions are continuous between elements."""
+        if self.family() in ["Lagrange", "Q", "S"] and self.degree() > 0:
+            return True
+        if self.family() == "Real":
+            return True
+        return False

--- a/ufl/finiteelement/finiteelementbase.py
+++ b/ufl/finiteelement/finiteelementbase.py
@@ -216,8 +216,4 @@ class FiniteElementBase(object):
 
     def is_fully_continuous(self):
         """Return true if the values of this element's basis functions are continuous between elements."""
-        if self.family() in ["Lagrange", "Q", "S"] and self.degree() > 0:
-            return True
-        if self.family() == "Real":
-            return True
-        return False
+        return (self.family() in ["Lagrange", "Q", "S"] and self.degree() > 0) or self.family() == "Real"

--- a/ufl/finiteelement/finiteelementbase.py
+++ b/ufl/finiteelement/finiteelementbase.py
@@ -214,6 +214,6 @@ class FiniteElementBase(object):
             return RestrictedElement(self, index)
         return NotImplemented
 
-    def is_fully_continuous(self):
+    def is_continuous(self):
         """Return true if the values of this element's basis functions are continuous between elements."""
         raise NotImplementedError()

--- a/ufl/finiteelement/finiteelementbase.py
+++ b/ufl/finiteelement/finiteelementbase.py
@@ -216,4 +216,4 @@ class FiniteElementBase(object):
 
     def is_fully_continuous(self):
         """Return true if the values of this element's basis functions are continuous between elements."""
-        return (self.family() in ["Lagrange", "Q", "S"] and self.degree() > 0) or self.family() == "Real"
+        raise NotImplementedError()

--- a/ufl/finiteelement/hdivcurl.py
+++ b/ufl/finiteelement/hdivcurl.py
@@ -48,7 +48,7 @@ class HDivElement(FiniteElementBase):
         "Format as string for pretty printing."
         return "HDivElement(%s)" % str(self._element.shortstr())
 
-    def is_fully_continuous(self):
+    def is_continuous(self):
         """Return true if the values of this element's basis functions are continuous between elements."""
         return False
 

--- a/ufl/finiteelement/hdivcurl.py
+++ b/ufl/finiteelement/hdivcurl.py
@@ -48,6 +48,10 @@ class HDivElement(FiniteElementBase):
         "Format as string for pretty printing."
         return "HDivElement(%s)" % str(self._element.shortstr())
 
+    def is_fully_continuous(self):
+        """Return true if the values of this element's basis functions are continuous between elements."""
+        return False
+
 
 class HCurlElement(FiniteElementBase):
     """A curl-conforming version of an outer product element, assuming
@@ -141,3 +145,7 @@ class WithMapping(FiniteElementBase):
 
     def shortstr(self):
         return "WithMapping(%s, %s)" % (self.wrapee.shortstr(), self._mapping)
+
+    def is_fully_continuous(self):
+        """Return true if the values of this element's basis functions are continuous between elements."""
+        return False

--- a/ufl/finiteelement/mixedelement.py
+++ b/ufl/finiteelement/mixedelement.py
@@ -243,6 +243,13 @@ class MixedElement(FiniteElementBase):
         tmp = ", ".join(element.shortstr() for element in self._sub_elements)
         return "Mixed<" + tmp + ">"
 
+    def is_fully_continuous(self):
+        """Return true if the values of this element's basis functions are continuous between elements."""
+        for e in self._sub_elements:
+            if not e.is_fully_continuous():
+                return False
+        return True
+
 
 class VectorElement(MixedElement):
     "A special case of a mixed finite element where all elements are equal."

--- a/ufl/finiteelement/mixedelement.py
+++ b/ufl/finiteelement/mixedelement.py
@@ -243,7 +243,7 @@ class MixedElement(FiniteElementBase):
         tmp = ", ".join(element.shortstr() for element in self._sub_elements)
         return "Mixed<" + tmp + ">"
 
-    def is_fully_continuous(self):
+    def is_continuous(self):
         """Return true if the values of this element's basis functions are continuous between elements."""
         return all(e.is_fully_continuous() for e in self._sub_elements)
 

--- a/ufl/finiteelement/mixedelement.py
+++ b/ufl/finiteelement/mixedelement.py
@@ -245,10 +245,7 @@ class MixedElement(FiniteElementBase):
 
     def is_fully_continuous(self):
         """Return true if the values of this element's basis functions are continuous between elements."""
-        for e in self._sub_elements:
-            if not e.is_fully_continuous():
-                return False
-        return True
+        return all(e.is_fully_continuous() for e in self._sub_elements)
 
 
 class VectorElement(MixedElement):

--- a/ufl/finiteelement/restrictedelement.py
+++ b/ufl/finiteelement/restrictedelement.py
@@ -99,4 +99,4 @@ class RestrictedElement(FiniteElementBase):
 
     def is_fully_continuous(self):
         """Return true if the values of this element's basis functions are continuous between elements."""
-        return self._element.is_fully_continuous()
+        return False

--- a/ufl/finiteelement/restrictedelement.py
+++ b/ufl/finiteelement/restrictedelement.py
@@ -96,3 +96,7 @@ class RestrictedElement(FiniteElementBase):
         #        w.r.t. different sub_elements meanings.
         "Return list of restricted sub elements."
         return (self._element,)
+
+    def is_fully_continuous(self):
+        """Return true if the values of this element's basis functions are continuous between elements."""
+        return self._element.is_fully_continuous()

--- a/ufl/finiteelement/restrictedelement.py
+++ b/ufl/finiteelement/restrictedelement.py
@@ -97,6 +97,6 @@ class RestrictedElement(FiniteElementBase):
         "Return list of restricted sub elements."
         return (self._element,)
 
-    def is_fully_continuous(self):
+    def is_continuous(self):
         """Return true if the values of this element's basis functions are continuous between elements."""
         return False

--- a/ufl/finiteelement/tensorproductelement.py
+++ b/ufl/finiteelement/tensorproductelement.py
@@ -15,7 +15,7 @@ from itertools import chain
 
 from ufl.log import error
 from ufl.cell import TensorProductCell, as_cell
-from ufl.sobolevspace import DirectionalSobolevSpace, H1, H2
+from ufl.sobolevspace import DirectionalSobolevSpace, H1
 
 from ufl.finiteelement.finiteelementbase import FiniteElementBase
 
@@ -119,4 +119,4 @@ class TensorProductElement(FiniteElementBase):
 
     def is_fully_continuous(self):
         """Return true if the values of this element's basis functions are continuous between elements."""
-        return self.sobolev_space() in [H1, H2]
+        return self.sobolev_space() in H1

--- a/ufl/finiteelement/tensorproductelement.py
+++ b/ufl/finiteelement/tensorproductelement.py
@@ -119,4 +119,4 @@ class TensorProductElement(FiniteElementBase):
 
     def is_fully_continuous(self):
         """Return true if the values of this element's basis functions are continuous between elements."""
-        return self.sobolev_space() in H1
+        return self in H1

--- a/ufl/finiteelement/tensorproductelement.py
+++ b/ufl/finiteelement/tensorproductelement.py
@@ -117,6 +117,6 @@ class TensorProductElement(FiniteElementBase):
         return "TensorProductElement(%s, cell=%s)" \
             % (', '.join([e.shortstr() for e in self._sub_elements]), str(self._cell))
 
-    def is_fully_continuous(self):
+    def is_continuous(self):
         """Return true if the values of this element's basis functions are continuous between elements."""
         return self in H1

--- a/ufl/finiteelement/tensorproductelement.py
+++ b/ufl/finiteelement/tensorproductelement.py
@@ -15,7 +15,7 @@ from itertools import chain
 
 from ufl.log import error
 from ufl.cell import TensorProductCell, as_cell
-from ufl.sobolevspace import DirectionalSobolevSpace
+from ufl.sobolevspace import DirectionalSobolevSpace, H1, H2
 
 from ufl.finiteelement.finiteelementbase import FiniteElementBase
 
@@ -116,3 +116,7 @@ class TensorProductElement(FiniteElementBase):
         "Short pretty-print."
         return "TensorProductElement(%s, cell=%s)" \
             % (', '.join([e.shortstr() for e in self._sub_elements]), str(self._cell))
+
+    def is_fully_continuous(self):
+        """Return true if the values of this element's basis functions are continuous between elements."""
+        return self.sobolev_space() in [H1, H2]


### PR DESCRIPTION
.. and remove a check on the family string name elsewhere.

This allows anyone writing a custom subclass of `finiteelementbase` to control which elements are continuous without being limited to three strings for family type