### PR TITLE
Fix signature for forms with identitcal constants and identical meshes (up to ufl_id)

### DIFF
--- a/ufl/constant.py
+++ b/ufl/constant.py
@@ -69,7 +69,8 @@ class Constant(Terminal):
     def _ufl_signature_data_(self, renumbering):
         "Signature data for constant depends on renumbering"
         return "Constant({}, {}, {})".format(
-            repr(self._ufl_domain), repr(self._ufl_shape), repr(renumbering[self]))
+            self._ufl_domain._ufl_signature_data_(renumbering), repr(self._ufl_shape),
+            repr(renumbering[self]))
 
 
 def VectorConstant(domain, count=None):

--- a/ufl/constant.py
+++ b/ufl/constant.py
@@ -66,6 +66,11 @@ class Constant(Terminal):
                 self._ufl_domain == other._ufl_domain and
                 self._ufl_shape == self._ufl_shape)
 
+    def _ufl_signature_data_(self, renumbering):
+        "Signature data for constant depends on renumbering"
+        return "Constant({}, {}, {})".format(
+            repr(self._ufl_domain), repr(self._ufl_shape), repr(renumbering[self]))
+
 
 def VectorConstant(domain, count=None):
     domain = as_domain(domain)

--- a/ufl/form.py
+++ b/ufl/form.py
@@ -81,6 +81,7 @@ class Form(object):
         "_arguments",
         "_coefficients",
         "_coefficient_numbering",
+        "_constant_numbering",
         "_constants",
         "_hash",
         "_signature",
@@ -111,9 +112,12 @@ class Form(object):
         self._arguments = None
         self._coefficients = None
         self._coefficient_numbering = None
+        self._constant_numbering = None
 
         from ufl.algorithms.analysis import extract_constants
         self._constants = extract_constants(self)
+        self._constant_numbering = dict(
+            (c, i) for i, c in enumerate(self._constants))
 
         # Internal variables for caching of hash and signature after
         # first request
@@ -236,6 +240,11 @@ class Form(object):
 
     def constants(self):
         return self._constants
+
+    def constant_numbering(self):
+        """Return a contiguous numbering of constants in a mapping
+        ``{constant:number}``."""
+        return self._constant_numbering
 
     def signature(self):
         "Signature for use with jit cache (independent of incidental numbering of indices etc.)"
@@ -458,9 +467,11 @@ class Form(object):
         # Include integration domains and coefficients in renumbering
         dn = self.domain_numbering()
         cn = self.coefficient_numbering()
+        cnstn = self.constant_numbering()
         renumbering = {}
         renumbering.update(dn)
         renumbering.update(cn)
+        renumbering.update(cnstn)
 
         # Add domains of coefficients, these may include domains not
         # among integration domains
@@ -477,6 +488,14 @@ class Form(object):
             d = a.ufl_function_space().ufl_domain()
             if d is not None and d not in renumbering:
                 renumbering[d] = k
+                k += 1
+
+        # Add domains of constants, these may include domains not
+        # among integration domains
+        for c in self._constants:
+            d = c.ufl_domain()
+            if c is not None and c not in renumbering:
+                renumbering[c] = k
                 k += 1
 
         return renumbering

--- a/ufl/form.py
+++ b/ufl/form.py
@@ -494,8 +494,8 @@ class Form(object):
         # among integration domains
         for c in self._constants:
             d = c.ufl_domain()
-            if c is not None and c not in renumbering:
-                renumbering[c] = k
+            if d is not None and d not in renumbering:
+                renumbering[d] = k
                 k += 1
 
         return renumbering


### PR DESCRIPTION
Reported at: https://fenicsproject.discourse.group/t/constant-in-dolfinx-and-ffcx-compilation/8968?u=dokken

Minimal example failing on main:
```python

import ufl

mesh = ufl.Mesh(ufl.VectorElement("Lagrange", ufl.triangle, 1))
c = ufl.Constant(mesh)
d = ufl.Constant(mesh)
a = c * ufl.dx
b = d * ufl.dx
assert(a.signature() == b.signature())
```

Constants now has the same behavior as coefficients:
```python
V = ufl.FunctionSpace(mesh, ufl.FiniteElement("CG", mesh.ufl_cell(), 1))
u = ufl.Coefficient(V)
v = ufl.TestFunction(V)
w = ufl.Coefficient(V)

a = ufl.inner(u, v) * ufl.dx
d = ufl.inner(w, v) * ufl.dx
assert(a.signature() == d.signature())
```

This PR now also supports same signature for different meshes (with same coordinate element), 
i.e.
```python
mesh = ufl.Mesh(ufl.VectorElement("Lagrange", ufl.triangle, 1))
mesh2 = ufl.Mesh(ufl.VectorElement("Lagrange", ufl.triangle, 1))
c = ufl.Constant(mesh)
d = ufl.Constant(mesh2)
a = c * ufl.dx
b = d * ufl.dx
assert(a.signature() == b.signature())
```