### PR TITLE
Add sobolev_space method to base finite element class

### DIFF
--- a/.github/workflows/fenicsx-tests.yml
+++ b/.github/workflows/fenicsx-tests.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           path: ./ffcx
           repository: FEniCS/ffcx
-          ref: main
+          ref: mscroggs/ufl-update
       - name: Install FFCx
         run: |
           cd ffcx
@@ -79,8 +79,8 @@ jobs:
 
       - name: Install Basix and FFCx
         run: |
-          python3 -m pip install git+https://github.com/FEniCS/basix.git
-          python3 -m pip install git+https://github.com/FEniCS/ffcx.git
+          python3 -m pip install git+https://github.com/FEniCS/basix.git@mscroggs/ufl-update
+          python3 -m pip install git+https://github.com/FEniCS/ffcx.git@mscroggs/ufl-update
 
       - name: Clone DOLFINx
         uses: actions/checkout@v2

--- a/.github/workflows/fenicsx-tests.yml
+++ b/.github/workflows/fenicsx-tests.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
     branches:
       - main
-      - h_inf_sobolev_space
 
 jobs:
   ffcx-tests:

--- a/.github/workflows/fenicsx-tests.yml
+++ b/.github/workflows/fenicsx-tests.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - main
+      - h_inf_sobolev_space
 
 jobs:
   ffcx-tests:

--- a/.github/workflows/fenicsx-tests.yml
+++ b/.github/workflows/fenicsx-tests.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install Basix
         run: |
-          python3 -m pip install git+https://github.com/FEniCS/basix.git
+          python3 -m pip install git+https://github.com/FEniCS/basix.git@mscroggs/ufl-update
 
       - name: Clone FFCx
         uses: actions/checkout@v2

--- a/.github/workflows/fenicsx-tests.yml
+++ b/.github/workflows/fenicsx-tests.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           path: ./ffcx
           repository: FEniCS/ffcx
-          ref: mscroggs/ufl-update
+          ref: mscroggs/ufl_update
       - name: Install FFCx
         run: |
           cd ffcx
@@ -80,7 +80,7 @@ jobs:
       - name: Install Basix and FFCx
         run: |
           python3 -m pip install git+https://github.com/FEniCS/basix.git@mscroggs/ufl-update
-          python3 -m pip install git+https://github.com/FEniCS/ffcx.git@mscroggs/ufl-update
+          python3 -m pip install git+https://github.com/FEniCS/ffcx.git@mscroggs/ufl_update
 
       - name: Clone DOLFINx
         uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ test/.pytest_cache
 *.egg-info
 dist/
 release/
+
+.*.swp

--- a/ufl/finiteelement/brokenelement.py
+++ b/ufl/finiteelement/brokenelement.py
@@ -14,7 +14,6 @@ class BrokenElement(FiniteElementBase):
     """The discontinuous version of an existing Finite Element space."""
     def __init__(self, element):
         self._element = element
-        self._repr = "BrokenElement(%s)" % repr(element)
 
         family = "BrokenElement"
         cell = element.cell()
@@ -25,6 +24,9 @@ class BrokenElement(FiniteElementBase):
         FiniteElementBase.__init__(self, family, cell, degree,
                                    quad_scheme, value_shape, reference_value_shape)
 
+    def __repr__(self):
+        return f"BrokenElement({repr(self._element)})"
+
     def mapping(self):
         return self._element.mapping()
 
@@ -32,8 +34,8 @@ class BrokenElement(FiniteElementBase):
         return BrokenElement(self._element.reconstruct(**kwargs))
 
     def __str__(self):
-        return "BrokenElement(%s)" % str(self._element)
+        return f"BrokenElement({repr(self._element)})"
 
     def shortstr(self):
-        "Format as string for pretty printing."
-        return "BrokenElement(%s)" % str(self._element.shortstr())
+        """Format as string for pretty printing."""
+        return f"BrokenElement({repr(self._element)})"

--- a/ufl/finiteelement/enrichedelement.py
+++ b/ufl/finiteelement/enrichedelement.py
@@ -61,14 +61,11 @@ class EnrichedElementBase(FiniteElementBase):
                                    quad_scheme, value_shape,
                                    reference_value_shape)
 
-        # Cache repr string
-        self._repr = "%s(%s)" % (class_name, ", ".join(repr(e) for e in self._elements))
-
     def mapping(self):
         return self._elements[0].mapping()
 
     def sobolev_space(self):
-        "Return the underlying Sobolev space."
+        """Return the underlying Sobolev space."""
         elements = [e for e in self._elements]
         if all(e.sobolev_space() == elements[0].sobolev_space()
                for e in elements):
@@ -104,6 +101,9 @@ class EnrichedElement(EnrichedElementBase):
         element is spatially constant over each cell."""
         return all(e.is_cellwise_constant() for e in self._elements)
 
+    def __repr__(self):
+        return "EnrichedElement(" + ", ".join(repr(e) for e in self._elements) + ")"
+
     def __str__(self):
         "Format as string for pretty printing."
         return "<%s>" % " + ".join(str(e) for e in self._elements)
@@ -126,6 +126,9 @@ class NodalEnrichedElement(EnrichedElementBase):
         """Return whether the basis functions of this
         element is spatially constant over each cell."""
         return False
+
+    def __repr__(self):
+        return "NodalEnrichedElement(" + ", ".join(repr(e) for e in self._elements) + ")"
 
     def __str__(self):
         "Format as string for pretty printing."

--- a/ufl/finiteelement/finiteelement.py
+++ b/ufl/finiteelement/finiteelement.py
@@ -24,10 +24,8 @@ from ufl.finiteelement.finiteelementbase import FiniteElementBase
 class FiniteElement(FiniteElementBase):
     "The basic finite element class for all simple finite elements."
     # TODO: Move these to base?
-    __slots__ = ("_short_name",
-                 "_sobolev_space",
-                 "_mapping",
-                 "_variant")
+    __slots__ = ("_short_name", "_sobolev_space",
+                 "_mapping", "_variant", "_repr")
 
     def __new__(cls,
                 family,
@@ -188,11 +186,16 @@ class FiniteElement(FiniteElementBase):
             repr(self.family()), repr(self.cell()), repr(self.degree()), quad_str, var_str)
         assert '"' not in self._repr
 
+    def __repr__(self):
+        """Format as string for evaluation as Python object."""
+        return self._repr
+
     def mapping(self):
+        """Return the mapping type for this element ."""
         return self._mapping
 
     def sobolev_space(self):
-        "Return the underlying Sobolev space."
+        """Return the underlying Sobolev space."""
         return self._sobolev_space
 
     def variant(self):

--- a/ufl/finiteelement/finiteelementbase.py
+++ b/ufl/finiteelement/finiteelementbase.py
@@ -15,24 +15,19 @@ from ufl.utils.sequences import product
 from ufl.utils.dicts import EmptyDict
 from ufl.log import error
 from ufl.cell import AbstractCell, as_cell
+from abc import ABC, abstractmethod
 
 
-class FiniteElementBase(object):
+class FiniteElementBase(ABC):
     "Base class for all finite elements."
-    __slots__ = ("_family",
-                 "_cell",
-                 "_degree",
-                 "_quad_scheme",
-                 "_value_shape",
-                 "_reference_value_shape",
-                 "_repr",
-                 "__weakref__")
+    __slots__ = ("_family", "_cell", "_degree", "_quad_scheme",
+                 "_value_shape", "_reference_value_shape", "__weakref__")
 
     # TODO: Not all these should be in the base class! In particular
     # family, degree, and quad_scheme do not belong here.
     def __init__(self, family, cell, degree, quad_scheme, value_shape,
                  reference_value_shape):
-        "Initialize basic finite element data."
+        """Initialize basic finite element data."""
         if not isinstance(family, str):
             error("Invalid family type.")
         if not (degree is None or isinstance(degree, (int, tuple))):
@@ -54,12 +49,20 @@ class FiniteElementBase(object):
         self._reference_value_shape = reference_value_shape
         self._quad_scheme = quad_scheme
 
+    @abstractmethod
     def __repr__(self):
-        """Format as string for evaluation as Python object.
+        """Format as string for evaluation as Python object."""
+        pass
 
-        NB! Assumes subclass has assigned its repr string to self._repr.
-        """
-        return self._repr
+    @abstractmethod
+    def sobolev_space(self):
+        """Return the underlying Sobolev space."""
+        pass
+
+    @abstractmethod
+    def mapping(self):
+        """Return the mapping type for this element."""
+        pass
 
     def _ufl_hash_data_(self):
         return repr(self)
@@ -100,10 +103,6 @@ class FiniteElementBase(object):
     def quadrature_scheme(self):
         "Return quadrature scheme of finite element."
         return self._quad_scheme
-
-    def mapping(self):
-        "Not implemented."
-        error("Missing implementation of mapping().")
 
     def cell(self):
         "Return cell of finite element."

--- a/ufl/finiteelement/hdivcurl.py
+++ b/ufl/finiteelement/hdivcurl.py
@@ -14,11 +14,10 @@ from ufl.sobolevspace import HDiv, HCurl
 class HDivElement(FiniteElementBase):
     """A div-conforming version of an outer product element, assuming
     this makes mathematical sense."""
-    __slots__ = ("_element",)
+    __slots__ = ("_element", )
 
     def __init__(self, element):
         self._element = element
-        self._repr = "HDivElement(%s)" % repr(element)
 
         family = "TensorProductElement"
         cell = element.cell()
@@ -31,22 +30,25 @@ class HDivElement(FiniteElementBase):
         FiniteElementBase.__init__(self, family, cell, degree,
                                    quad_scheme, value_shape, reference_value_shape)
 
+    def __repr__(self):
+        return f"HDivElement({repr(self._element)})"
+
     def mapping(self):
         return "contravariant Piola"
 
     def sobolev_space(self):
-        "Return the underlying Sobolev space."
+        """Return the underlying Sobolev space."""
         return HDiv
 
     def reconstruct(self, **kwargs):
         return HDivElement(self._element.reconstruct(**kwargs))
 
     def __str__(self):
-        return "HDivElement(%s)" % str(self._element)
+        return f"HDivElement({repr(self._element)})"
 
     def shortstr(self):
-        "Format as string for pretty printing."
-        return "HDivElement(%s)" % str(self._element.shortstr())
+        """Format as string for pretty printing."""
+        return f"HDivElement({self._element.shortstr()})"
 
 
 class HCurlElement(FiniteElementBase):
@@ -56,7 +58,6 @@ class HCurlElement(FiniteElementBase):
 
     def __init__(self, element):
         self._element = element
-        self._repr = "HCurlElement(%s)" % repr(element)
 
         family = "TensorProductElement"
         cell = element.cell()
@@ -70,6 +71,9 @@ class HCurlElement(FiniteElementBase):
         FiniteElementBase.__init__(self, family, cell, degree, quad_scheme,
                                    value_shape, reference_value_shape)
 
+    def __repr__(self):
+        return f"HCurlElement({repr(self._element)})"
+
     def mapping(self):
         return "covariant Piola"
 
@@ -81,11 +85,11 @@ class HCurlElement(FiniteElementBase):
         return HCurlElement(self._element.reconstruct(**kwargs))
 
     def __str__(self):
-        return "HCurlElement(%s)" % str(self._element)
+        return f"HCurlElement({repr(self._element)})"
 
     def shortstr(self):
         "Format as string for pretty printing."
-        return "HCurlElement(%s)" % str(self._element.shortstr())
+        return f"HCurlElement({self._element.shortstr()})"
 
 
 class WithMapping(FiniteElementBase):
@@ -95,7 +99,6 @@ class WithMapping(FiniteElementBase):
     remapped = WithMapping(E, "identity")
     """
     def __init__(self, wrapee, mapping):
-        self._repr = "WithMapping(%s, %s)" % (repr(wrapee), mapping)
         if mapping == "symmetries":
             raise ValueError("Can't change mapping to 'symmetries'")
         self._mapping = mapping
@@ -107,6 +110,9 @@ class WithMapping(FiniteElementBase):
         except AttributeError:
             raise AttributeError("'%s' object has no attribute '%s'" %
                                  (type(self).__name__, attr))
+
+    def __repr__(self):
+        return f"WithMapping({repr(self.wrapee)}, {self._mapping})"
 
     def value_shape(self):
         gdim = self.cell().geometric_dimension()
@@ -137,7 +143,7 @@ class WithMapping(FiniteElementBase):
         return type(self)(wrapee, mapping)
 
     def __str__(self):
-        return "WithMapping(%s, mapping=%s)" % (self.wrapee, self._mapping)
+        return f"WithMapping({repr(self.wrapee)}, {self._mapping})"
 
     def shortstr(self):
-        return "WithMapping(%s, %s)" % (self.wrapee.shortstr(), self._mapping)
+        return f"WithMapping({self.wrapee.shortstr()}, {self._mapping})"

--- a/ufl/finiteelement/mixedelement.py
+++ b/ufl/finiteelement/mixedelement.py
@@ -124,7 +124,7 @@ class MixedElement(FiniteElementBase):
         return sm or EmptyDict
 
     def sobolev_space(self):
-        return min(e.sobolev_space() for e in self._sub_elements)
+        return max(e.sobolev_space() for e in self._sub_elements)
 
     def mapping(self):
         if all(e.mapping() == "identity" for e in self._sub_elements):

--- a/ufl/finiteelement/mixedelement.py
+++ b/ufl/finiteelement/mixedelement.py
@@ -90,10 +90,8 @@ class MixedElement(FiniteElementBase):
         FiniteElementBase.__init__(self, "Mixed", cell, degree, quad_scheme,
                                    value_shape, reference_value_shape)
 
-        # Cache repr string
-        if type(self) is MixedElement:
-            self._repr = "MixedElement(%s)" % (
-                ", ".join(repr(e) for e in self._sub_elements),)
+    def __repr__(self):
+        return "MixedElement(" + ", ".join(repr(e) for e in self._sub_elements) + ")"
 
     def reconstruct_from_elements(self, *elements):
         "Reconstruct a mixed element from new subelements."
@@ -124,6 +122,9 @@ class MixedElement(FiniteElementBase):
         if j != product(self.value_shape()):
             error("Size mismatch in symmetry algorithm.")
         return sm or EmptyDict
+
+    def sobolev_space(self):
+        return min(e.sobolev_space() for e in self._sub_elements)
 
     def mapping(self):
         if all(e.mapping() == "identity" for e in self._sub_elements):
@@ -247,6 +248,8 @@ class MixedElement(FiniteElementBase):
 class VectorElement(MixedElement):
     "A special case of a mixed finite element where all elements are equal."
 
+    __slots__ = ("_repr", "_mapping", "_sub_element")
+
     def __init__(self, family, cell=None, degree=None, dim=None,
                  form_degree=None, quad_scheme=None, variant=None):
         """
@@ -310,8 +313,10 @@ class VectorElement(MixedElement):
             var_str = ", variant='" + variant + "'"
 
         # Cache repr string
-        self._repr = "VectorElement(%s, dim=%d%s)" % (
-            repr(sub_element), len(self._sub_elements), var_str)
+        self._repr = f"VectorElement({repr(sub_element)}, dim={dim}{var_str})"
+
+    def __repr__(self):
+        return self._repr
 
     def reconstruct(self, **kwargs):
         sub_element = self._sub_element.reconstruct(**kwargs)
@@ -343,7 +348,7 @@ class TensorElement(MixedElement):
     __slots__ = ("_sub_element", "_shape", "_symmetry",
                  "_sub_element_mapping",
                  "_flattened_sub_element_mapping",
-                 "_mapping")
+                 "_mapping", "_repr")
 
     def __init__(self, family, cell=None, degree=None, shape=None,
                  symmetry=None, quad_scheme=None, variant=None):
@@ -447,8 +452,11 @@ class TensorElement(MixedElement):
             var_str = ", variant='" + variant + "'"
 
         # Cache repr string
-        self._repr = "TensorElement(%s, shape=%s, symmetry=%s%s)" % (
-            repr(sub_element), repr(self._shape), repr(self._symmetry), var_str)
+        self._repr = (f"TensorElement({repr(sub_element)}, shape={shape}, "
+                      f"symmetry={symmetry}{var_str})")
+
+    def __repr__(self):
+        return self._repr
 
     def variant(self):
         """Return the variant used to initialise the element."""

--- a/ufl/finiteelement/restrictedelement.py
+++ b/ufl/finiteelement/restrictedelement.py
@@ -35,8 +35,8 @@ class RestrictedElement(FiniteElementBase):
 
         self._restriction_domain = restriction_domain
 
-        self._repr = "RestrictedElement(%s, %s)" % (
-            repr(self._element), repr(self._restriction_domain))
+    def __repr__(self):
+        return f"RestrictedElement({repr(self._element)}, {repr(self._restriction_domain)})"
 
     def is_cellwise_constant(self):
         """Return whether the basis functions of this element is spatially

--- a/ufl/finiteelement/restrictedelement.py
+++ b/ufl/finiteelement/restrictedelement.py
@@ -13,6 +13,7 @@
 
 from ufl.finiteelement.finiteelementbase import FiniteElementBase
 from ufl.log import error
+from ufl.sobolevspaces import L2
 
 valid_restriction_domains = ("interior", "facet", "face", "edge", "vertex")
 
@@ -37,6 +38,9 @@ class RestrictedElement(FiniteElementBase):
 
     def __repr__(self):
         return f"RestrictedElement({repr(self._element)}, {repr(self._restriction_domain)})"
+
+    def sobolev_space(self):
+        return L2
 
     def is_cellwise_constant(self):
         """Return whether the basis functions of this element is spatially

--- a/ufl/finiteelement/restrictedelement.py
+++ b/ufl/finiteelement/restrictedelement.py
@@ -13,7 +13,7 @@
 
 from ufl.finiteelement.finiteelementbase import FiniteElementBase
 from ufl.log import error
-from ufl.sobolevspaces import L2
+from ufl.sobolevspace import L2
 
 valid_restriction_domains = ("interior", "facet", "face", "edge", "vertex")
 

--- a/ufl/finiteelement/tensorproductelement.py
+++ b/ufl/finiteelement/tensorproductelement.py
@@ -68,8 +68,11 @@ class TensorProductElement(FiniteElementBase):
                                    reference_value_shape)
         self._sub_elements = elements
         self._cell = cell
-        self._repr = "TensorProductElement(%s, cell=%s)" % (
-            ", ".join(repr(e) for e in elements), repr(cell))
+
+    def __repr__(self):
+        return "TensorProductElement(" + ", ".join(
+            repr(e) for e in self._subelements
+        ) + f", {repr(self._cell)})"
 
     def mapping(self):
         if all(e.mapping() == "identity" for e in self._sub_elements):

--- a/ufl/finiteelement/tensorproductelement.py
+++ b/ufl/finiteelement/tensorproductelement.py
@@ -71,7 +71,7 @@ class TensorProductElement(FiniteElementBase):
 
     def __repr__(self):
         return "TensorProductElement(" + ", ".join(
-            repr(e) for e in self._subelements
+            repr(e) for e in self._sub_elements
         ) + f", {repr(self._cell)})"
 
     def mapping(self):


### PR DESCRIPTION
Added sobolev_space method to base finite element class

Made base finite element class into an abc abstract class, so that elements cannot be created without methods such as sobolev_space being implemented

This builds on #117, and is currently set to merge into that branch so it can be part of that PR.