### PR TITLE
Override is_cellwise_constant for CellNormal

### DIFF
--- a/ufl/geometry.py
+++ b/ufl/geometry.py
@@ -649,6 +649,11 @@ class CellNormal(GeometricCellQuantity):
         # return (g-t,g) # TODO: Should it be CellNormals? For interval in 3D we have two!
         return (g,)
 
+    def is_cellwise_constant(self):
+        "Return whether this expression is spatially constant over each cell."
+        # Only true for a piecewise linear coordinate field in simplex cells
+        return self._domain.is_piecewise_linear_simplex_domain()
+
 
 @ufl_type()
 class ReferenceNormal(GeometricFacetQuantity):


### PR DESCRIPTION
Following MWE produces `True`, 
```python
import ufl

coord_el = ufl.VectorElement("CG", ufl.triangle, 2, dim=3)
mesh = ufl.Mesh(coord_el)

n = ufl.CellNormal(mesh)
print(n.is_cellwise_constant())
```
which results in terms like `grad(CellNormal)` being incorrectly simplified to `Zero`.