### PR TITLE
Allow multiple subdomain data

### DIFF
--- a/.github/workflows/fenicsx-tests.yml
+++ b/.github/workflows/fenicsx-tests.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           path: ./dolfinx
           repository: FEniCS/dolfinx
-          ref: jpdean/multiple_subdomain_data
+          ref: main
       - name: Install DOLFINx
         run: |
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build -S dolfinx/cpp/

--- a/.github/workflows/fenicsx-tests.yml
+++ b/.github/workflows/fenicsx-tests.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           path: ./dolfinx
           repository: FEniCS/dolfinx
-          ref: jpdean/manual_integration_domains_2
+          ref: jpdean/multiple_subdomain_data
       - name: Install DOLFINx
         run: |
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build -S dolfinx/cpp/

--- a/.github/workflows/fenicsx-tests.yml
+++ b/.github/workflows/fenicsx-tests.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           path: ./dolfinx
           repository: FEniCS/dolfinx
-          ref: main
+          ref: jpdean/manual_integration_domains_2
       - name: Install DOLFINx
         run: |
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build -S dolfinx/cpp/

--- a/test/test_measures.py
+++ b/test/test_measures.py
@@ -185,23 +185,33 @@ def test_foo():
     domain, = Mx.ufl_domains()
     assert domain.ufl_id() == mydomain.ufl_id()
     assert domain.ufl_cargo() == mymesh
-    assert Mx.subdomain_data()[mydomain]["cell"] == cell_domains
+    assert(len(Mx.subdomain_data()[mydomain]["cell"]) == 1)
+    assert(Mx.subdomain_data()[mydomain]["cell"][0]) == cell_domains
 
     domain, = Ms.ufl_domains()
     assert domain.ufl_cargo() == mymesh
-    assert Ms.subdomain_data()[mydomain][
-        "exterior_facet"] == exterior_facet_domains
+    assert(len(Ms.subdomain_data()[mydomain][
+        "exterior_facet"]) == 1)
+    assert(Ms.subdomain_data()[mydomain][
+        "exterior_facet"][0]) == exterior_facet_domains
 
     domain, = MS.ufl_domains()
     assert domain.ufl_cargo() == mymesh
-    assert MS.subdomain_data()[mydomain][
-        "interior_facet"] == interior_facet_domains
+    assert(len(MS.subdomain_data()[mydomain][
+        "interior_facet"]) == 1)
+    assert(MS.subdomain_data()[mydomain][
+        "interior_facet"][0] == interior_facet_domains)
 
     # Test joining of these domains in a single form
     domain, = M.ufl_domains()
     assert domain.ufl_cargo() == mymesh
-    assert M.subdomain_data()[mydomain]["cell"] == cell_domains
-    assert M.subdomain_data()[mydomain][
-        "exterior_facet"] == exterior_facet_domains
-    assert M.subdomain_data()[mydomain][
-        "interior_facet"] == interior_facet_domains
+    assert(len(M.subdomain_data()[mydomain]["cell"]) == 1)
+    assert(M.subdomain_data()[mydomain]["cell"][0] == cell_domains)
+    assert(len(M.subdomain_data()[mydomain][
+        "exterior_facet"]) == 1)
+    assert(M.subdomain_data()[mydomain][
+        "exterior_facet"][0] == exterior_facet_domains)
+    assert(len(M.subdomain_data()[mydomain][
+        "interior_facet"]) == 1)
+    assert(M.subdomain_data()[mydomain][
+        "interior_facet"][0] == interior_facet_domains)

--- a/test/test_measures.py
+++ b/test/test_measures.py
@@ -109,26 +109,26 @@ def test_foo():
     # domain=None,
     # subdomain_id="everywhere",
     # metadata=None)
-    assert dx.ufl_domain() == None
+    assert dx.ufl_domain() is None
     assert dx.subdomain_id() == "everywhere"
 
     # Set subdomain_id to "everywhere", still no domain set
     dxe = dx()
-    assert dxe.ufl_domain() == None
+    assert dxe.ufl_domain() is None
     assert dxe.subdomain_id() == "everywhere"
 
     # Set subdomain_id to 5, still no domain set
     dx5 = dx(5)
-    assert dx5.ufl_domain() == None
+    assert dx5.ufl_domain() is None
     assert dx5.subdomain_id() == 5
 
     # Check that original dx is untouched
-    assert dx.ufl_domain() == None
+    assert dx.ufl_domain() is None
     assert dx.subdomain_id() == "everywhere"
 
     # Set subdomain_id to (2,3), still no domain set
     dx23 = dx((2, 3))
-    assert dx23.ufl_domain() == None
+    assert dx23.ufl_domain() is None
     assert dx23.subdomain_id(), (2 == 3)
 
     # Map metadata to metadata, ffc interprets as before
@@ -136,7 +136,7 @@ def test_foo():
     # assert dxm.metadata() == {"dummy":123}
     assert dxm.metadata() == {"dummy": 123}  # Deprecated, TODO: Remove
 
-    assert dxm.ufl_domain() == None
+    assert dxm.ufl_domain() is None
     assert dxm.subdomain_id() == "everywhere"
 
     # dxm = dx(metadata={"dummy":123})
@@ -144,7 +144,7 @@ def test_foo():
     dxm = dx(metadata={"dummy": 123})
     assert dxm.metadata() == {"dummy": 123}
 
-    assert dxm.ufl_domain() == None
+    assert dxm.ufl_domain() is None
     assert dxm.subdomain_id() == "everywhere"
 
     dxi = dx(metadata={"quadrature_degree": 3})
@@ -168,9 +168,9 @@ def test_foo():
     dSd = dS[interior_facet_domains]
     # Current behaviour: no domain created, measure domain data is a single
     # object not a full dict
-    assert dxd.ufl_domain() == None
-    assert dsd.ufl_domain() == None
-    assert dSd.ufl_domain() == None
+    assert dxd.ufl_domain() is None
+    assert dsd.ufl_domain() is None
+    assert dSd.ufl_domain() is None
     assert dxd.subdomain_data() is cell_domains
     assert dsd.subdomain_data() is exterior_facet_domains
     assert dSd.subdomain_data() is interior_facet_domains
@@ -185,33 +185,25 @@ def test_foo():
     domain, = Mx.ufl_domains()
     assert domain.ufl_id() == mydomain.ufl_id()
     assert domain.ufl_cargo() == mymesh
-    assert(len(Mx.subdomain_data()[mydomain]["cell"]) == 1)
-    assert(Mx.subdomain_data()[mydomain]["cell"][0]) == cell_domains
+    assert len(Mx.subdomain_data()[mydomain]["cell"]) == 1
+    assert Mx.subdomain_data()[mydomain]["cell"][0] == cell_domains
 
     domain, = Ms.ufl_domains()
     assert domain.ufl_cargo() == mymesh
-    assert(len(Ms.subdomain_data()[mydomain][
-        "exterior_facet"]) == 1)
-    assert(Ms.subdomain_data()[mydomain][
-        "exterior_facet"][0]) == exterior_facet_domains
+    assert len(Ms.subdomain_data()[mydomain]["exterior_facet"]) == 1
+    assert Ms.subdomain_data()[mydomain]["exterior_facet"][0] == exterior_facet_domains
 
     domain, = MS.ufl_domains()
     assert domain.ufl_cargo() == mymesh
-    assert(len(MS.subdomain_data()[mydomain][
-        "interior_facet"]) == 1)
-    assert(MS.subdomain_data()[mydomain][
-        "interior_facet"][0] == interior_facet_domains)
+    assert len(MS.subdomain_data()[mydomain]["interior_facet"]) == 1
+    assert MS.subdomain_data()[mydomain]["interior_facet"][0] == interior_facet_domains
 
     # Test joining of these domains in a single form
     domain, = M.ufl_domains()
     assert domain.ufl_cargo() == mymesh
-    assert(len(M.subdomain_data()[mydomain]["cell"]) == 1)
-    assert(M.subdomain_data()[mydomain]["cell"][0] == cell_domains)
-    assert(len(M.subdomain_data()[mydomain][
-        "exterior_facet"]) == 1)
-    assert(M.subdomain_data()[mydomain][
-        "exterior_facet"][0] == exterior_facet_domains)
-    assert(len(M.subdomain_data()[mydomain][
-        "interior_facet"]) == 1)
-    assert(M.subdomain_data()[mydomain][
-        "interior_facet"][0] == interior_facet_domains)
+    assert len(M.subdomain_data()[mydomain]["cell"]) == 1
+    assert M.subdomain_data()[mydomain]["cell"][0] == cell_domains
+    assert len(M.subdomain_data()[mydomain]["exterior_facet"]) == 1
+    assert M.subdomain_data()[mydomain]["exterior_facet"][0] == exterior_facet_domains
+    assert len(M.subdomain_data()[mydomain]["interior_facet"]) == 1
+    assert M.subdomain_data()[mydomain]["interior_facet"][0] == interior_facet_domains

--- a/ufl/form.py
+++ b/ufl/form.py
@@ -431,14 +431,10 @@ class Form(object):
             sd = integral.subdomain_data()
 
             # Collect subdomain data
-            data = subdomain_data[domain].get(it)
-            if data is None:
-                subdomain_data[domain][it] = sd
-            elif sd is not None:
-                if data.ufl_id() != sd.ufl_id():
-                    error(
-                        "Integrals in form have different subdomain_data objects."
-                    )
+            if subdomain_data[domain].get(it) is None:
+                subdomain_data[domain][it] = [sd]
+            else:
+                subdomain_data[domain][it].append(sd)
         self._subdomain_data = subdomain_data
 
     def _analyze_form_arguments(self):


### PR DESCRIPTION
Currently, UFL checks that all integrals of a particular type in a form have the same subdomain data (using the UFL ID). I'm not sure this should be UFL's job. Instead,  UFL should probably just collect the data into a list and let the finite element library (e.g. dolfinx) either check the data is the same or make use of the additional data. This PR addresses this.

This PR requires https://github.com/FEniCS/dolfinx/pull/2369