### PR TITLE
Add variant to EnrichedElement, TensorProductElement, etc

### DIFF
--- a/ufl/finiteelement/enrichedelement.py
+++ b/ufl/finiteelement/enrichedelement.py
@@ -82,6 +82,13 @@ class EnrichedElementBase(FiniteElementBase):
             sobolev_space, = intersect
             return sobolev_space
 
+    def variant(self):
+        elements = [e for e in self._elements]
+        if all(e.variant() == elements[0].variant()
+               for e in elements):
+            return elements[0].variant()
+        return None
+
     def reconstruct(self, **kwargs):
         return type(self)(*[e.reconstruct(**kwargs) for e in self._elements])
 

--- a/ufl/finiteelement/enrichedelement.py
+++ b/ufl/finiteelement/enrichedelement.py
@@ -83,11 +83,11 @@ class EnrichedElementBase(FiniteElementBase):
             return sobolev_space
 
     def variant(self):
-        elements = [e for e in self._elements]
-        if all(e.variant() == elements[0].variant()
-               for e in elements):
-            return elements[0].variant()
-        return None
+        try:
+            variant, = {e.variant() for e in self._elements}
+            return variant
+        except ValueError:
+            return None
 
     def reconstruct(self, **kwargs):
         return type(self)(*[e.reconstruct(**kwargs) for e in self._elements])

--- a/ufl/finiteelement/hdivcurl.py
+++ b/ufl/finiteelement/hdivcurl.py
@@ -43,6 +43,9 @@ class HDivElement(FiniteElementBase):
     def reconstruct(self, **kwargs):
         return HDivElement(self._element.reconstruct(**kwargs))
 
+    def variant(self):
+        return self._element.variant()
+
     def __str__(self):
         return f"HDivElement({repr(self._element)})"
 
@@ -83,6 +86,9 @@ class HCurlElement(FiniteElementBase):
 
     def reconstruct(self, **kwargs):
         return HCurlElement(self._element.reconstruct(**kwargs))
+
+    def variant(self):
+        return self._element.variant()
 
     def __str__(self):
         return f"HCurlElement({repr(self._element)})"
@@ -141,6 +147,9 @@ class WithMapping(FiniteElementBase):
         mapping = kwargs.pop("mapping", self._mapping)
         wrapee = self.wrapee.reconstruct(**kwargs)
         return type(self)(wrapee, mapping)
+
+    def variant(self):
+        return self.wrapee.variant()
 
     def __str__(self):
         return f"WithMapping({repr(self.wrapee)}, {self._mapping})"

--- a/ufl/finiteelement/restrictedelement.py
+++ b/ufl/finiteelement/restrictedelement.py
@@ -100,3 +100,6 @@ class RestrictedElement(FiniteElementBase):
         #        w.r.t. different sub_elements meanings.
         "Return list of restricted sub elements."
         return (self._element,)
+
+    def variant(self):
+        return self._element.variant()

--- a/ufl/finiteelement/tensorproductelement.py
+++ b/ufl/finiteelement/tensorproductelement.py
@@ -110,6 +110,13 @@ class TensorProductElement(FiniteElementBase):
         cell = kwargs.pop("cell", self.cell())
         return TensorProductElement(*[e.reconstruct(**kwargs) for e in self.sub_elements()], cell=cell)
 
+    def variant(self):
+        elements = self._sub_elements
+        if all(e.variant() == elements[0].variant()
+               for e in elements):
+            return elements[0].variant()
+        return None
+
     def __str__(self):
         "Pretty-print."
         return "TensorProductElement(%s, cell=%s)" \

--- a/ufl/finiteelement/tensorproductelement.py
+++ b/ufl/finiteelement/tensorproductelement.py
@@ -111,11 +111,11 @@ class TensorProductElement(FiniteElementBase):
         return TensorProductElement(*[e.reconstruct(**kwargs) for e in self.sub_elements()], cell=cell)
 
     def variant(self):
-        elements = self._sub_elements
-        if all(e.variant() == elements[0].variant()
-               for e in elements):
-            return elements[0].variant()
-        return None
+        try:
+            variant, = {e.variant() for e in self.sub_elements()}
+            return variant
+        except ValueError:
+            return None
 
     def __str__(self):
         "Pretty-print."


### PR DESCRIPTION
This PR lets composite elements return the `variant` property of their sub-elements. When the sub-elements are of different variants, `variant()` returns `None`.