### PR TITLE
Implement sobolev_space() for BrokenElement and WithMapping

### DIFF
--- a/ufl/finiteelement/brokenelement.py
+++ b/ufl/finiteelement/brokenelement.py
@@ -8,6 +8,7 @@
 # Modified by Massimiliano Leoni, 2016
 
 from ufl.finiteelement.finiteelementbase import FiniteElementBase
+from ufl.sobolevspace import L2
 
 
 class BrokenElement(FiniteElementBase):
@@ -29,6 +30,10 @@ class BrokenElement(FiniteElementBase):
 
     def mapping(self):
         return self._element.mapping()
+
+    def sobolev_space(self):
+        """Return the underlying Sobolev space."""
+        return L2
 
     def reconstruct(self, **kwargs):
         return BrokenElement(self._element.reconstruct(**kwargs))

--- a/ufl/finiteelement/hdivcurl.py
+++ b/ufl/finiteelement/hdivcurl.py
@@ -81,7 +81,7 @@ class HCurlElement(FiniteElementBase):
         return "covariant Piola"
 
     def sobolev_space(self):
-        "Return the underlying Sobolev space."
+        """Return the underlying Sobolev space."""
         return HCurl
 
     def reconstruct(self, **kwargs):
@@ -94,7 +94,7 @@ class HCurlElement(FiniteElementBase):
         return f"HCurlElement({repr(self._element)})"
 
     def shortstr(self):
-        "Format as string for pretty printing."
+        """Format as string for pretty printing."""
         return f"HCurlElement({self._element.shortstr()})"
 
 
@@ -142,6 +142,10 @@ class WithMapping(FiniteElementBase):
 
     def mapping(self):
         return self._mapping
+
+    def sobolev_space(self):
+        """Return the underlying Sobolev space."""
+        return self.wrapee.sobolev_space()
 
     def reconstruct(self, **kwargs):
         mapping = kwargs.pop("mapping", self._mapping)

--- a/ufl/finiteelement/hdivcurl.py
+++ b/ufl/finiteelement/hdivcurl.py
@@ -8,7 +8,7 @@
 # Modified by Massimiliano Leoni, 2016
 
 from ufl.finiteelement.finiteelementbase import FiniteElementBase
-from ufl.sobolevspace import HDiv, HCurl
+from ufl.sobolevspace import HDiv, HCurl, L2
 
 
 class HDivElement(FiniteElementBase):
@@ -145,7 +145,10 @@ class WithMapping(FiniteElementBase):
 
     def sobolev_space(self):
         """Return the underlying Sobolev space."""
-        return self.wrapee.sobolev_space()
+        if self.wrapee.mapping() == self.mapping():
+            return self.wrapee.sobolev_space()
+        else:
+            return L2
 
     def reconstruct(self, **kwargs):
         mapping = kwargs.pop("mapping", self._mapping)


### PR DESCRIPTION
Since #117, `sobolev_space()` is an abstract method, and a couple elements were not implementing this method.