### PR TITLE
Fix FEniCSx integration action

### DIFF
--- a/.github/workflows/fenicsx-tests.yml
+++ b/.github/workflows/fenicsx-tests.yml
@@ -15,6 +15,7 @@ jobs:
     env:
       CC: gcc-10
       CXX: g++-10
+      PETSC_ARCH: linux-gnu-real-64
 
     steps:
       - uses: actions/checkout@v3

--- a/README.rst
+++ b/README.rst
@@ -40,3 +40,4 @@ License
 
   You should have received a copy of the GNU Lesser General Public License
   along with this program. If not, see <https://www.gnu.org/licenses/>.
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ ci =
 
 [flake8]
 ignore = E501, W504,
-         E741                   # ambiguous variable name
+         E741
 builtins = ufl
 exclude = .git,__pycache__,doc/sphinx/source/conf.py,build,dist,test
 


### PR DESCRIPTION
Added PETSC_ARCH to environment variables.

Removed comment from setup.cfg (as this was causing flake8 to fail)