### PR TITLE
Pass more variants around

### DIFF
--- a/ufl/finiteelement/mixedelement.py
+++ b/ufl/finiteelement/mixedelement.py
@@ -234,6 +234,13 @@ class MixedElement(FiniteElementBase):
     def reconstruct(self, **kwargs):
         return MixedElement(*[e.reconstruct(**kwargs) for e in self.sub_elements()])
 
+    def variant(self):
+        try:
+            variant, = {e.variant() for e in self.sub_elements()}
+            return variant
+        except ValueError:
+            return None
+
     def __str__(self):
         "Format as string for pretty printing."
         tmp = ", ".join(str(element) for element in self._sub_elements)


### PR DESCRIPTION
The are plans to remove the variant argument from elements in the UFL rewrite, but it would be useful to include these in a release of UFL before we start major changes to the interface

Combines #17 and #129