### PR TITLE
Simplify coeff and constant naming

### DIFF
--- a/ufl/coefficient.py
+++ b/ufl/coefficient.py
@@ -88,11 +88,7 @@ class Coefficient(FormArgument):
         return ("Coefficient", count, fsdata)
 
     def __str__(self):
-        count = str(self._count)
-        if len(count) == 1:
-            return "w_%s" % count
-        else:
-            return "w_{%s}" % count
+        return f"w_{self._count}"
 
     def __repr__(self):
         return self._repr

--- a/ufl/constant.py
+++ b/ufl/constant.py
@@ -48,11 +48,7 @@ class Constant(Terminal):
         return True
 
     def __str__(self):
-        count = str(self._count)
-        if len(count) == 1:
-            return "c_%s" % count
-        else:
-            return "c_{%s}" % count
+        return f"c_{self._count}"
 
     def __repr__(self):
         return self._repr


### PR DESCRIPTION
This fixes a problem with coefficient names in `ffcx`. The current naming is probably for LaTeX compatibility, but I feel this should be a secondary consideration.
See https://github.com/FEniCS/ffcx/issues/551