### PR TITLE
Add tests for legacy DOLFIN

### DIFF
--- a/.github/workflows/fenicsx-tests.yml
+++ b/.github/workflows/fenicsx-tests.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ffcx-tests:
     name: Run FFCx tests

--- a/.github/workflows/legacy-fenics-tests.yml
+++ b/.github/workflows/legacy-fenics-tests.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install UFL
         run: |
-          pip3 install .
+          python3 -m pip install .
 
       - name: Install FIAT
         run: |
@@ -44,8 +44,8 @@ jobs:
       - name: Install FFC
         run: |
           cd ffc
-          pip install .
-          pip install libs/ffc-factory
+          python3 -m pip install .
+          python3 -m pip install libs/ffc-factory
       - name: Install pytest
         run: python3 -m pip install pytest pytest-xdist
       - name: Run FFC unit tests
@@ -68,7 +68,7 @@ jobs:
 
       - name: Install UFL
         run: |
-          pip3 install .
+          python3 -m pip install .
 
       - name: Install FIAT, Dijitso and FFC
         run: |

--- a/.github/workflows/legacy-fenics-tests.yml
+++ b/.github/workflows/legacy-fenics-tests.yml
@@ -92,6 +92,28 @@ jobs:
           cd build
           cmake ..
           make install
+          python3 -m pip install --no-dependencies python
+      - name: Install pytest
+        run: python3 -m pip install pytest pytest-xdist
+      - name: Run DOLFIN unit tests
+        run: python3 -m pytest -n auto dolfin/python/test/unit
+
+
+
+  dolfin-tests-alternative:
+    name: Run DOLFIN tests (using Jorgen's container)
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/scientificcomputing/fenics:2023-01-16
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install UFL
+        run: |
+          python3 -m pip install .
+
+      - name: Clone DOLFIN
+        run: git clone https://bitbucket.org/fenics-project/dolfin.git dolfin
       - name: Install pytest
         run: python3 -m pip install pytest pytest-xdist
       - name: Run DOLFIN unit tests

--- a/.github/workflows/legacy-fenics-tests.yml
+++ b/.github/workflows/legacy-fenics-tests.yml
@@ -36,6 +36,10 @@ jobs:
         run: |
           python3 -m pip install git+https://github.com/FEniCS/fiat.git
 
+      - name: Install Dijitso
+        run: |
+          python3 -m pip install git+https://bitbucket.org/fenics-project/dijitso.git
+
       - name: Clone FFC
         run: git clone https://bitbucket.org/fenics-project/ffc.git ffc
       - name: Install FFC
@@ -45,51 +49,48 @@ jobs:
       - name: Run FFC unit tests
         run: python3 -m pytest -n auto ffc/test
 
-  #dolfinx-tests:
-  #  name: Run DOLFINx tests
-  #  runs-on: ubuntu-latest
-  #  container: fenicsproject/test-env:nightly-openmpi
+  dolfin-tests:
+    name: Run DOLFIN tests
+    runs-on: ubuntu-latest
+    container: fenicsproject/test-env:nightly-openmpi
 
-  #  env:
-  #    CC: clang
-  #    CXX: clang++
-#
-#      PETSC_ARCH: linux-gnu-complex-32
-#      OMPI_ALLOW_RUN_AS_ROOT: 1
-#      OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
-#      OMPI_MCA_rmaps_base_oversubscribe: 1
-#      OMPI_MCA_plm: isolated
-#      OMPI_MCA_btl_vader_single_copy_mechanism: none
-#      OMPI_MCA_mpi_yield_when_idle: 1
-#      OMPI_MCA_hwloc_base_binding_policy: none
+    env:
+      CC: clang
+      CXX: clang++
 
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Install dependencies (Python)
-#        run: |
-#          python3 -m pip install --upgrade pip
-#
-#      - name: Install UFL
-#        run: |
-#          pip3 install .
-#
-#      - name: Install Basix and FFCx
-#        run: |
-#          python3 -m pip install git+https://github.com/FEniCS/basix.git
-#          python3 -m pip install git+https://github.com/FEniCS/ffcx.git
-#
-#      - name: Clone DOLFINx
-#        uses: actions/checkout@v3
-#        with:
-#          path: ./dolfinx
-#          repository: FEniCS/dolfinx
-#          ref: main
-#      - name: Install DOLFINx
-#        run: |
-#          cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build -S dolfinx/cpp/
-#          cmake --build build
-#          cmake --install build
-#          pip3 -v install --global-option build --global-option --debug dolfinx/python/
-#      - name: Run DOLFINx unit tests
-#        run: python3 -m pytest -n auto dolfinx/python/test/unit
+      PETSC_ARCH: linux-gnu-complex-32
+      OMPI_ALLOW_RUN_AS_ROOT: 1
+      OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
+      OMPI_MCA_rmaps_base_oversubscribe: 1
+      OMPI_MCA_plm: isolated
+      OMPI_MCA_btl_vader_single_copy_mechanism: none
+      OMPI_MCA_mpi_yield_when_idle: 1
+      OMPI_MCA_hwloc_base_binding_policy: none
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies (Python)
+        run: |
+          python3 -m pip install --upgrade pip
+
+      - name: Install UFL
+        run: |
+          pip3 install .
+
+      - name: Install FIAT, Dijitso and FFC
+        run: |
+          python3 -m pip install git+https://github.com/FEniCS/fiat.git
+          python3 -m pip install git+https://bitbucket.org/fenics-project/dijitso.git
+          python3 -m pip install git+https://bitbucket.org/fenics-project/ffc.git
+
+      - name: Clone DOLFIN
+        run: git clone https://bitbucket.org/fenics-project/dolfin.git dolfin
+      - name: Install DOLFIN
+        run: |
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build -S dolfin/cpp/
+          cmake --build build
+          cmake --install build
+          pip3 -v install --global-option build --global-option --debug dolfin/python/
+      - name: Run DOLFIN unit tests
+        run: python3 -m pytest -n auto dolfin/python/test/unit
 

--- a/.github/workflows/legacy-fenics-tests.yml
+++ b/.github/workflows/legacy-fenics-tests.yml
@@ -15,7 +15,6 @@ jobs:
     env:
       CC: gcc-10
       CXX: g++-10
-      PETSC_ARCH: linux-gnu-real-64
 
     steps:
       - uses: actions/checkout@v3
@@ -54,20 +53,10 @@ jobs:
   dolfin-tests:
     name: Run DOLFIN tests
     runs-on: ubuntu-latest
-    container: fenicsproject/test-env:nightly-openmpi
 
     env:
-      CC: clang
-      CXX: clang++
-
-      PETSC_ARCH: linux-gnu-complex-32
-      OMPI_ALLOW_RUN_AS_ROOT: 1
-      OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
-      OMPI_MCA_rmaps_base_oversubscribe: 1
-      OMPI_MCA_plm: isolated
-      OMPI_MCA_btl_vader_single_copy_mechanism: none
-      OMPI_MCA_mpi_yield_when_idle: 1
-      OMPI_MCA_hwloc_base_binding_policy: none
+      CC: gcc-10
+      CXX: g++-10
 
     steps:
       - uses: actions/checkout@v3
@@ -89,10 +78,11 @@ jobs:
         run: git clone https://bitbucket.org/fenics-project/dolfin.git dolfin
       - name: Install DOLFIN
         run: |
-          cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build -S dolfin/cpp/
-          cmake --build build
-          cmake --install build
-          pip3 -v install --global-option build --global-option --debug dolfin/python/
+          cd dolfin
+          mkdir build
+          cd build
+          cmake ..
+          make install
       - name: Install pytest
         run: python3 -m pip install pytest pytest-xdist
       - name: Run DOLFIN unit tests

--- a/.github/workflows/legacy-fenics-tests.yml
+++ b/.github/workflows/legacy-fenics-tests.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Install Boost, Eigen3
-        run: sudo apt-get install -y libboost-all-dev, libeigen3-dev
+        run: sudo apt-get install -y libboost-all-dev libeigen3-dev
       - name: Install UFL
         run: |
           python3 -m pip install .

--- a/.github/workflows/legacy-fenics-tests.yml
+++ b/.github/workflows/legacy-fenics-tests.yml
@@ -46,6 +46,8 @@ jobs:
         run: |
           cd ffc
           pip install .
+      - name: Install pytest
+        run: python3 -m pip install pytest pytest-xdist
       - name: Run FFC unit tests
         run: python3 -m pytest -n auto ffc/test
 
@@ -91,6 +93,8 @@ jobs:
           cmake --build build
           cmake --install build
           pip3 -v install --global-option build --global-option --debug dolfin/python/
+      - name: Install pytest
+        run: python3 -m pip install pytest pytest-xdist
       - name: Run DOLFIN unit tests
         run: python3 -m pytest -n auto dolfin/python/test/unit
 

--- a/.github/workflows/legacy-fenics-tests.yml
+++ b/.github/workflows/legacy-fenics-tests.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ffc-tests:
     name: Run FFC tests

--- a/.github/workflows/legacy-fenics-tests.yml
+++ b/.github/workflows/legacy-fenics-tests.yml
@@ -71,10 +71,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Install boost
-        uses: MarkusJx/install-boost@v2.4.1
-        id: install-boost
-        with:
-            boost_version: 1.73.0
+        run: apt-get install -y libboost-all-dev
       - name: Install UFL
         run: |
           python3 -m pip install .

--- a/.github/workflows/legacy-fenics-tests.yml
+++ b/.github/workflows/legacy-fenics-tests.yml
@@ -62,10 +62,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: mpi4py/setup-mpi@v1
-      - name: Install dependencies (Python)
-        run: |
-          python3 -m pip install --upgrade pip
-
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.9
+      - name: Install boost
+        uses: MarkusJx/install-boost@v2.4.1
+        id: install-boost
+        with:
+            boost_version: 1.73.0
       - name: Install UFL
         run: |
           python3 -m pip install .

--- a/.github/workflows/legacy-fenics-tests.yml
+++ b/.github/workflows/legacy-fenics-tests.yml
@@ -62,6 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: mpi4py/setup-mpi@v1
+      - name: Set up Python
         uses: actions/setup-python@v3
         with:
           python-version: 3.9

--- a/.github/workflows/legacy-fenics-tests.yml
+++ b/.github/workflows/legacy-fenics-tests.yml
@@ -78,6 +78,7 @@ jobs:
           cd build
           cmake ..
           make install
+          cd ../
           python3 -m pip install python/
         #
       - name: Install pytest

--- a/.github/workflows/legacy-fenics-tests.yml
+++ b/.github/workflows/legacy-fenics-tests.yml
@@ -69,9 +69,9 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: 3.9
-      - name: Install Boost, Eigen3, PETSc, SLEPc
+      - name: Install Boost, Eigen3, PETSc, SLEPc, etc
         run: |
-          sudo apt-get install -y libboost-all-dev libeigen3-dev
+          sudo apt-get install -y clang cmake g++ git gfortran libboost-dev libboost-filesystem-dev libboost-iostreams-dev libboost-math-dev libboost-program-options-dev libboost-system-dev libboost-thread-dev libboost-timer-dev libeigen3-dev libhdf5-mpich-dev liblapack-dev libmpich-dev libopenblas-dev ninja-build pkg-config python3-numpy python3-matplotlib python3-scipy wget
           python3 -m pip install petsc4py slepc4py
       - name: Install UFL
         run: |

--- a/.github/workflows/legacy-fenics-tests.yml
+++ b/.github/workflows/legacy-fenics-tests.yml
@@ -68,7 +68,18 @@ jobs:
           python3 -m pip install .
 
       - name: Clone DOLFIN
-        run: git clone https://bitbucket.org/fenics-project/dolfin.git dolfin
+        # run: git clone https://bitbucket.org/fenics-project/dolfin.git dolfin
+        run: git clone -b Matthew-Scroggs/readmerst-edited-online-with-bitbucket-1674041780358 https://bitbucket.org/mscroggs/dolfin-1.git dolfin
+        # TODO: remove this install step once back on main DOLFIN branch
+      - name: Install DOFLFIN
+        run: |
+          cd dolfin
+          mkdir build
+          cd build
+          cmake ..
+          make install
+          python3 -m pip install python/
+        #
       - name: Install pytest
         run: python3 -m pip install pytest pytest-xdist
       - name: Run DOLFIN unit tests

--- a/.github/workflows/legacy-fenics-tests.yml
+++ b/.github/workflows/legacy-fenics-tests.yml
@@ -58,51 +58,6 @@ jobs:
   dolfin-tests:
     name: Run DOLFIN tests
     runs-on: ubuntu-latest
-
-    env:
-      CC: gcc-10
-      CXX: g++-10
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v3
-        with:
-          python-version: 3.9
-      - name: Install Boost, Eigen3, PETSc, SLEPc, etc
-        run: |
-          sudo apt-get install -y clang cmake g++ git gfortran libboost-dev libboost-filesystem-dev libboost-iostreams-dev libboost-math-dev libboost-program-options-dev libboost-system-dev libboost-thread-dev libboost-timer-dev libeigen3-dev libhdf5-mpich-dev liblapack-dev libmpich-dev libopenblas-dev ninja-build pkg-config python3-numpy python3-matplotlib python3-scipy wget
-          python3 -m pip install petsc4py slepc4py
-      - name: Install UFL
-        run: |
-          python3 -m pip install .
-
-      - name: Install FIAT, Dijitso and FFC
-        run: |
-          python3 -m pip install git+https://github.com/FEniCS/fiat.git
-          python3 -m pip install git+https://bitbucket.org/fenics-project/dijitso.git
-          python3 -m pip install git+https://bitbucket.org/fenics-project/ffc.git
-
-      - name: Clone DOLFIN
-        run: git clone https://bitbucket.org/fenics-project/dolfin.git dolfin
-      - name: Install DOLFIN
-        run: |
-          cd dolfin
-          mkdir build
-          cd build
-          cmake ..
-          make install
-          python3 -m pip install --no-dependencies python
-      - name: Install pytest
-        run: python3 -m pip install pytest pytest-xdist
-      - name: Run DOLFIN unit tests
-        run: python3 -m pytest -n auto dolfin/python/test/unit
-
-
-
-  dolfin-tests-alternative:
-    name: Run DOLFIN tests (using Jorgen's container)
-    runs-on: ubuntu-latest
     container:
       image: ghcr.io/scientificcomputing/fenics:2023-01-16
 

--- a/.github/workflows/legacy-fenics-tests.yml
+++ b/.github/workflows/legacy-fenics-tests.yml
@@ -37,12 +37,7 @@ jobs:
           python3 -m pip install git+https://github.com/FEniCS/fiat.git
 
       - name: Clone FFC
-        uses: actions/checkout@v3
-        with:
-          path: ./ffc
-          repository: fenics-project/ffc
-          ref: master
-          github-server-url: https://bitbucket.org
+        run: git clone https://bitbucket.org/fenics-project/ffc.git ffc
       - name: Install FFC
         run: |
           cd ffc

--- a/.github/workflows/legacy-fenics-tests.yml
+++ b/.github/workflows/legacy-fenics-tests.yml
@@ -70,8 +70,8 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: 3.9
-      - name: Install boost
-        run: sudo apt-get install -y libboost-all-dev
+      - name: Install Boost, Eigen3
+        run: sudo apt-get install -y libboost-all-dev, libeigen3-dev
       - name: Install UFL
         run: |
           python3 -m pip install .

--- a/.github/workflows/legacy-fenics-tests.yml
+++ b/.github/workflows/legacy-fenics-tests.yml
@@ -60,6 +60,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - uses: mpi4py/setup-mpi@v1
       - name: Install dependencies (Python)
         run: |
           python3 -m pip install --upgrade pip

--- a/.github/workflows/legacy-fenics-tests.yml
+++ b/.github/workflows/legacy-fenics-tests.yml
@@ -45,6 +45,7 @@ jobs:
         run: |
           cd ffc
           pip install .
+          pip install libs/ffc-factory
       - name: Install pytest
         run: python3 -m pip install pytest pytest-xdist
       - name: Run FFC unit tests

--- a/.github/workflows/legacy-fenics-tests.yml
+++ b/.github/workflows/legacy-fenics-tests.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Install boost
-        run: apt-get install -y libboost-all-dev
+        run: sudo apt-get install -y libboost-all-dev
       - name: Install UFL
         run: |
           python3 -m pip install .

--- a/.github/workflows/legacy-fenics-tests.yml
+++ b/.github/workflows/legacy-fenics-tests.yml
@@ -65,7 +65,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: mpi4py/setup-mpi@v1
       - name: Set up Python
         uses: actions/setup-python@v3
         with:

--- a/.github/workflows/legacy-fenics-tests.yml
+++ b/.github/workflows/legacy-fenics-tests.yml
@@ -1,0 +1,100 @@
+# This workflow will install FIAT, FFC, DOLFIN and run the DOLFIN and FFC unit tests.
+
+name: FEniCS integration
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  ffc-tests:
+    name: Run FFC tests
+    runs-on: ubuntu-latest
+
+    env:
+      CC: gcc-10
+      CXX: g++-10
+      PETSC_ARCH: linux-gnu-real-64
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.9
+
+      - name: Install test dependencies
+        run: |
+          sudo apt-get install -y graphviz libgraphviz-dev ninja-build pkg-config
+
+      - name: Install UFL
+        run: |
+          pip3 install .
+
+      - name: Install FIAT
+        run: |
+          python3 -m pip install git+https://github.com/FEniCS/fiat.git
+
+      - name: Clone FFC
+        uses: actions/checkout@v3
+        with:
+          path: ./ffc
+          repository: fenics-project/ffc
+          ref: master
+          github-server-ufl: https://bitbucket.org
+      - name: Install FFC
+        run: |
+          cd ffc
+          pip install .
+      - name: Run FFC unit tests
+        run: python3 -m pytest -n auto ffc/test
+
+  #dolfinx-tests:
+  #  name: Run DOLFINx tests
+  #  runs-on: ubuntu-latest
+  #  container: fenicsproject/test-env:nightly-openmpi
+
+  #  env:
+  #    CC: clang
+  #    CXX: clang++
+#
+#      PETSC_ARCH: linux-gnu-complex-32
+#      OMPI_ALLOW_RUN_AS_ROOT: 1
+#      OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
+#      OMPI_MCA_rmaps_base_oversubscribe: 1
+#      OMPI_MCA_plm: isolated
+#      OMPI_MCA_btl_vader_single_copy_mechanism: none
+#      OMPI_MCA_mpi_yield_when_idle: 1
+#      OMPI_MCA_hwloc_base_binding_policy: none
+
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Install dependencies (Python)
+#        run: |
+#          python3 -m pip install --upgrade pip
+#
+#      - name: Install UFL
+#        run: |
+#          pip3 install .
+#
+#      - name: Install Basix and FFCx
+#        run: |
+#          python3 -m pip install git+https://github.com/FEniCS/basix.git
+#          python3 -m pip install git+https://github.com/FEniCS/ffcx.git
+#
+#      - name: Clone DOLFINx
+#        uses: actions/checkout@v3
+#        with:
+#          path: ./dolfinx
+#          repository: FEniCS/dolfinx
+#          ref: main
+#      - name: Install DOLFINx
+#        run: |
+#          cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build -S dolfinx/cpp/
+#          cmake --build build
+#          cmake --install build
+#          pip3 -v install --global-option build --global-option --debug dolfinx/python/
+#      - name: Run DOLFINx unit tests
+#        run: python3 -m pytest -n auto dolfinx/python/test/unit
+

--- a/.github/workflows/legacy-fenics-tests.yml
+++ b/.github/workflows/legacy-fenics-tests.yml
@@ -42,7 +42,7 @@ jobs:
           path: ./ffc
           repository: fenics-project/ffc
           ref: master
-          github-server-ufl: https://bitbucket.org
+          github-server-url: https://bitbucket.org
       - name: Install FFC
         run: |
           cd ffc

--- a/.github/workflows/legacy-fenics-tests.yml
+++ b/.github/workflows/legacy-fenics-tests.yml
@@ -69,8 +69,10 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: 3.9
-      - name: Install Boost, Eigen3
-        run: sudo apt-get install -y libboost-all-dev libeigen3-dev
+      - name: Install Boost, Eigen3, PETSc, SLEPc
+        run: |
+          sudo apt-get install -y libboost-all-dev libeigen3-dev
+          python3 -m pip install petsc4py slepc4py
       - name: Install UFL
         run: |
           python3 -m pip install .

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -14,6 +14,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tsfc-tests.yml
+++ b/.github/workflows/tsfc-tests.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tsfc-tests:
     name: Run TSFC tests

--- a/ufl/__init__.py
+++ b/ufl/__init__.py
@@ -362,6 +362,9 @@ from ufl.objects import (
 # Useful constants
 from math import e, pi
 
+# Deprecated
+from ufl.log import WARNING
+
 __all__ = [
     'product',
     'as_cell', 'AbstractCell', 'Cell', 'TensorProductCell',
@@ -417,4 +420,6 @@ __all__ = [
     'quadrilateral', 'hexahedron', 'facet',
     'i', 'j', 'k', 'l', 'p', 'q', 'r', 's',
     'e', 'pi',
+    # Deprecated
+    'WARNING'
 ]

--- a/ufl/__init__.py
+++ b/ufl/__init__.py
@@ -363,7 +363,7 @@ from ufl.objects import (
 from math import e, pi
 
 # Deprecated
-from ufl.log import WARNING
+from ufl.log import WARNING, UFLException
 
 __all__ = [
     'product',
@@ -421,5 +421,5 @@ __all__ = [
     'i', 'j', 'k', 'l', 'p', 'q', 'r', 's',
     'e', 'pi',
     # Deprecated
-    'WARNING'
+    'WARNING', 'UFLException'
 ]

--- a/ufl/cell.py
+++ b/ufl/cell.py
@@ -84,6 +84,12 @@ num_cell_entities = {"vertex": (1,),
 # Mapping from cell name to topological dimension
 cellname2dim = dict((k, len(v) - 1) for k, v in num_cell_entities.items())
 
+# TODO: Remove this dict
+cellname2facetname = {"interval": "vertex",
+                      "triangle": "interval",
+                      "quadrilateral": "interval",
+                      "tetrahedron": "triangle",
+                      "hexahedron": "quadrilateral"}
 
 # --- Basic cell representation classes
 

--- a/ufl/cell.py
+++ b/ufl/cell.py
@@ -91,6 +91,7 @@ cellname2facetname = {"interval": "vertex",
                       "tetrahedron": "triangle",
                       "hexahedron": "quadrilateral"}
 
+
 # --- Basic cell representation classes
 
 @attach_operators_from_hash_data

--- a/ufl/core/expr.py
+++ b/ufl/core/expr.py
@@ -391,6 +391,11 @@ class Expr(object, metaclass=UFLType):
             val = NotImplemented
         return val
 
+    def geometric_dimension(self):
+        """This function is deprecated and will be removed after June 2023."""
+        from ufl.domain import find_geometric_dimension
+        return find_geometric_dimension(self)
+
 
 # Initializing traits here because Expr is not defined in the class
 # declaration

--- a/ufl/log.py
+++ b/ufl/log.py
@@ -15,7 +15,7 @@ import sys
 import types
 import logging
 import warnings
-from logging import DEBUG, INFO, ERROR, CRITICAL  # noqa: F401
+from logging import DEBUG, INFO, ERROR, CRITICAL, WARNING  # noqa: F401
 
 log_functions = ["log", "debug", "info", "error",
                  "begin", "end",

--- a/ufl/log.py
+++ b/ufl/log.py
@@ -1,0 +1,222 @@
+# -*- coding: utf-8 -*-
+"""This module provides functions used by the UFL implementation to
+output messages. These may be redirected by the user of UFL."""
+
+# Copyright (C) 2005-2016 Anders Logg and Martin Sandve Alnaes
+#
+# This file is part of UFL (https://www.fenicsproject.org)
+#
+# SPDX-License-Identifier:    LGPL-3.0-or-later
+#
+# Modified by Johan Hake, 2009.
+# Modified by Massimiliano Leoni, 2016
+
+import sys
+import types
+import logging
+import warnings
+from logging import DEBUG, INFO, ERROR, CRITICAL  # noqa: F401
+
+log_functions = ["log", "debug", "info", "error",
+                 "begin", "end",
+                 "set_level", "push_level", "pop_level", "set_indent",
+                 "add_indent",
+                 "set_handler", "get_handler", "get_logger", "add_logfile",
+                 "set_prefix",
+                 "info_red", "info_green", "info_blue"]
+
+__all__ = log_functions + ["Logger", "log_functions"] +\
+    ["DEBUG", "INFO", "ERROR", "CRITICAL"]
+
+
+# This is used to override emit() in StreamHandler for printing
+# without newline
+def emit(self, record):
+    message = self.format(record)
+    format_string = "%s" if getattr(record, "continued", False) else "%s\n"
+    self.stream.write(format_string % message)
+    self.flush()
+
+
+# Colors if the terminal supports it (disabled e.g. when piped to
+# file)
+if sys.stdout.isatty() and sys.stderr.isatty():
+    RED = "\033[1;37;31m%s\033[0m"
+    BLUE = "\033[1;37;34m%s\033[0m"
+    GREEN = "\033[1;37;32m%s\033[0m"
+else:
+    RED = "%s"
+    BLUE = "%s"
+    GREEN = "%s"
+
+
+# Logger class
+class Logger:
+
+    def __init__(self, name, exception_type=Exception):
+        "Create logger instance."
+        self._name = name
+        self._exception_type = exception_type
+
+        # Set up handler
+        h = logging.StreamHandler(sys.stdout)
+        h.setLevel(ERROR)
+        # Override emit() in handler for indentation
+        h.emit = types.MethodType(emit, h)
+        self._handler = h
+
+        # Set up logger
+        self._log = logging.getLogger(name)
+        assert len(self._log.handlers) == 0
+        self._log.addHandler(h)
+        self._log.setLevel(DEBUG)
+
+        self._logfiles = {}
+
+        # Set initial indentation level
+        self._indent_level = 0
+
+        # Setup stack with default logging level
+        self._level_stack = [DEBUG]
+
+        # Set prefix
+        self._prefix = ""
+
+    def add_logfile(self, filename=None, mode="a", level=DEBUG):
+        "Add a log file."
+        if filename is None:
+            filename = "%s.log" % self._name
+        if filename in self._logfiles:
+            warnings.warn("Adding logfile %s multiple times." % filename)
+            return
+        h = logging.FileHandler(filename, mode)
+        h.emit = types.MethodType(emit, h)
+        h.setLevel(level)
+        self._log.addHandler(h)
+        self._logfiles[filename] = h
+        return h
+
+    def get_logfile_handler(self, filename):
+        "Gets the handler to the file identified by the given file name."
+        return self._logfiles[filename]
+
+    def log(self, level, *message):
+        "Write a log message on given log level."
+        text = self._format_raw(*message)
+        if len(text) >= 3 and text[-3:] == "...":
+            self._log.log(level, self._format(*message),
+                          extra={"continued": True})
+        else:
+            self._log.log(level, self._format(*message))
+
+    def debug(self, *message):
+        "Write debug message."
+        self.log(DEBUG, *message)
+
+    def info(self, *message):
+        "Write info message."
+        self.log(INFO, *message)
+
+    def info_red(self, *message):
+        "Write info message in red."
+        self.log(INFO, RED % self._format_raw(*message))
+
+    def info_green(self, *message):
+        "Write info message in green."
+        self.log(INFO, GREEN % self._format_raw(*message))
+
+    def info_blue(self, *message):
+        "Write info message in blue."
+        self.log(INFO, BLUE % self._format_raw(*message))
+
+    def error(self, *message):
+        "Write error message and raise an exception."
+        self._log.error(*message)
+        raise self._exception_type(self._format_raw(*message))
+
+    def begin(self, *message):
+        "Begin task: write message and increase indentation level."
+        self.info(*message)
+        self.info("-" * len(self._format_raw(*message)))
+        self.add_indent()
+
+    def end(self):
+        "End task: write a newline and decrease indentation level."
+        self.info("")
+        self.add_indent(-1)
+
+    def push_level(self, level):
+        "Push a log level on the level stack."
+        self._level_stack.append(level)
+        self.set_level(level)
+
+    def pop_level(self):
+        "Pop log level from the level stack, reverting to before the last push_level."
+        self._level_stack.pop()
+        level = self._level_stack[-1]
+        self.set_level(level)
+
+    def set_level(self, level):
+        "Set log level."
+        self._level_stack[-1] = level
+        self._handler.setLevel(level)
+
+    def set_indent(self, level):
+        "Set indentation level."
+        self._indent_level = level
+
+    def add_indent(self, increment=1):
+        "Add to indentation level."
+        self._indent_level += increment
+
+    def get_handler(self):
+        "Get handler for logging."
+        return self._handler
+
+    def set_handler(self, handler):
+        """Replace handler for logging.
+        To add additional handlers instead of replacing the existing one, use
+        `log.get_logger().addHandler(myhandler)`.
+        See the logging module for more details.
+        """
+        self._log.removeHandler(self._handler)
+        self._log.addHandler(handler)
+        self._handler = handler
+        handler.emit = types.MethodType(emit, self._handler)
+
+    def get_logger(self):
+        "Return message logger."
+        return self._log
+
+    def set_prefix(self, prefix):
+        "Set prefix for log messages."
+        self._prefix = prefix
+
+    def _format(self, *message):
+        "Format message including indentation."
+        indent = self._prefix + 2 * self._indent_level * " "
+        return "\n".join([indent + line for line in (message[0] % message[1:]).split("\n")])
+
+    def _format_raw(self, *message):
+        "Format message without indentation."
+        return message[0] % message[1:]
+
+
+# --- Set up global log functions ---
+
+class UFLException(Exception):
+    "Base class for UFL exceptions."
+    pass
+
+
+class UFLValueError(UFLException):
+    "Value type error."
+    pass
+
+
+ufl_logger = Logger("UFL", UFLException)
+
+for foo in log_functions:
+    exec("%s = ufl_logger.%s" % (foo, foo))
+
+set_level(ERROR)  # noqa

--- a/ufl/log.py
+++ b/ufl/log.py
@@ -1,5 +1,6 @@
-# -*- coding: utf-8 -*-
-"""This module provides functions used by the UFL implementation to
+"""This module is deprecated and will be removed after June 2023.
+
+This module provides functions used by the UFL implementation to
 output messages. These may be redirected by the user of UFL."""
 
 # Copyright (C) 2005-2016 Anders Logg and Martin Sandve Alnaes

--- a/ufl/log.py
+++ b/ufl/log.py
@@ -129,6 +129,22 @@ class Logger:
         "Write info message in blue."
         self.log(INFO, BLUE % self._format_raw(*message))
 
+    def warning(self, *message):
+        "Write warning message."
+        self._log.warning(self._format(*message))
+
+    def warning_red(self, *message):
+        "Write warning message in red."
+        self._log.warning(RED % self._format(*message))
+
+    def warning_green(self, *message):
+        "Write warning message in green."
+        self._log.warning(GREEN % self._format(*message))
+
+    def warning_blue(self, *message):
+        "Write warning message in blue."
+        self._log.warning(BLUE % self._format(*message))
+
     def error(self, *message):
         "Write error message and raise an exception."
         self._log.error(*message)


### PR DESCRIPTION
We should (temporarily) run tests against legacy FFC/DOLFIN so that we know which release is the final release compatible with legacy FEniCS

Temporarily readded (to make compatible with FFC):

- ufl/log.py
- cellname2facetname in ufl/cell.py
- geometric_dimension in core/expr.py