### PR TITLE
Add concurrency to workflows

### DIFF
--- a/.github/workflows/fenicsx-tests.yml
+++ b/.github/workflows/fenicsx-tests.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ffcx-tests:
     name: Run FFCx tests

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -14,6 +14,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tsfc-tests.yml
+++ b/.github/workflows/tsfc-tests.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tsfc-tests:
     name: Run TSFC tests


### PR DESCRIPTION
This will make GitHub actions cancel workflows that are currently running on a branch if a new commit is pushed