### PR TITLE
Use BaseArgument.__eq__ in Argument

### DIFF
--- a/ufl/argument.py
+++ b/ufl/argument.py
@@ -152,6 +152,7 @@ class Argument(FormArgument, BaseArgument):
     __getnewargs__ = BaseArgument.__getnewargs__
     __str__ = BaseArgument.__str__
     _ufl_signature_data_ = BaseArgument._ufl_signature_data_
+    __eq__ = BaseArgument.__eq__
 
     def __new__(cls, *args, **kw):
         if args[0] and is_dual(args[0]):


### PR DESCRIPTION
Otherwise, `Argument.__eq__` is inherited from the first parent class, `FormArgument`, which has the equality from `Terminal` which is very inefficient.

I do not know if this is the right thing, but it makes `Argument.__eq__` behave as before the #87 .

Fixes https://github.com/FEniCS/ffcx/issues/552