### PR TITLE
Fix dev version number so pip doesn't report UFL as upgradable

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 # future
 [metadata]
 name = fenics-ufl
-version = 2022.3.0.dev0
+version = 2023.2.0.dev0
 author = FEniCS Project Contributors
 email = fenics-dev@googlegroups.com
 maintainer = FEniCS Project Steering Council


### PR DESCRIPTION
Version number in `main` wasn't updated at last release.