### PR TITLE
fix str

### DIFF
--- a/test/test_str.py
+++ b/test/test_str.py
@@ -103,3 +103,8 @@ def test_str_list_matrix_with_zero():
 
 # FIXME: Add more tests for tensors collapsing
 #        partly or completely into Zero!
+
+
+def test_str_element():
+    elem = FiniteElement("Q", quadrilateral, 1)
+    assert str(elem) == "<Q1 on a quadrilateral>"

--- a/ufl/finiteelement/finiteelement.py
+++ b/ufl/finiteelement/finiteelement.py
@@ -153,7 +153,7 @@ class FiniteElement(FiniteElementBase):
         # simplify base though.
         self._sobolev_space = sobolev_space
         self._mapping = mapping
-        self._short_name = short_name
+        self._short_name = short_name or family
         self._variant = variant
 
         # Finite elements on quadrilaterals and hexahedrons have an IrreducibleInt as degree


### PR DESCRIPTION
This PR fixes `str`.

```
from ufl import *
  

elem = FiniteElement("Q", quadrilateral, 1)
print(elem)
```
currently prints:
```
<None1 on a quadrilateral>
```
instead of:
```
<Q1 on a quadrilateral>
```