### PR TITLE
Update UFL repository references

### DIFF
--- a/doc/sphinx/source/installation.rst
+++ b/doc/sphinx/source/installation.rst
@@ -30,8 +30,8 @@ Installation instructions
 =========================
 
 To install UFL, download the source code from the
-`UFL Bitbucket repository
-<https://bitbucket.org/fenics-project/ufl>`__,
+`UFL GitHub repository
+<https://github.com/FEniCS/ufl>`__,
 and run the following command:
 
 .. code-block:: console

--- a/ufl/__init__.py
+++ b/ufl/__init__.py
@@ -38,7 +38,7 @@ and
 
 The development version can be found in the repository at
 
-  https://www.bitbucket.org/fenics-project/ufl
+  https://github.com/FEniCS/ufl
 
 A very brief overview of the language contents follows:
 


### PR DESCRIPTION
I know it's unimportant, but it may improve user experience.

At least, that was the case for me: when I was reading the documentation and found the old Bitbucket UFL repository links, I wondered if I was reading the most up-to-date documentation. Eventually, I found it was; but I had already spent five minutes checking it.