### PR TITLE
Remove `type_extensions` dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,6 @@ setup_requires =
     wheel
 install_requires =
     numpy
-    typing_extensions; python_version < "3.11"
 
 [options.extras_require]
 docs = sphinx; sphinx_rtd_theme

--- a/ufl/cell.py
+++ b/ufl/cell.py
@@ -15,12 +15,6 @@ import weakref
 from ufl.core.ufl_type import UFLObject
 from abc import abstractmethod
 
-try:
-    from typing import Self
-except ImportError:
-    # This alternative is needed pre Python 3.11
-    # Delete this after 04 Oct 2026 (Python 3.10 end of life)
-    from typing_extensions import Self
 
 __all_classes__ = ["AbstractCell", "Cell", "TensorProductCell"]
 
@@ -44,7 +38,7 @@ class AbstractCell(UFLObject):
         """Return True if all the facets of this cell are simplex cells."""
 
     @abstractmethod
-    def _lt(self, other: Self) -> bool:
+    def _lt(self, other) -> bool:
         """Define an arbitrarily chosen but fixed sort order for all instances of this type with the same dimensions."""
 
     @abstractmethod
@@ -276,7 +270,7 @@ class Cell(AbstractCell):
         except IndexError:
             return ()
 
-    def _lt(self, other: Self) -> bool:
+    def _lt(self, other) -> bool:
         return self._cellname < other._cellname
 
     def cellname(self) -> str:
@@ -385,7 +379,7 @@ class TensorProductCell(AbstractCell):
             return [self]
         raise NotImplementedError(f"TensorProductCell.sub_entities({dim}) is not implemented.")
 
-    def _lt(self, other: Self) -> bool:
+    def _lt(self, other) -> bool:
         return self._ufl_hash_data_() < other._ufl_hash_data_()
 
     def cellname(self) -> str:


### PR DESCRIPTION
It introduced an extra dependency (for Python < 3.11) but used in very few places. The extra, somewhat esoteric, dependency complicates Spack builds.

In the mid-term, we can require python 3.11 rather than require type_extensions.

Fixes #174.