### PR TITLE
Make `FiniteElementBase` subscriptable but not iterable

### DIFF
--- a/ufl/finiteelement/finiteelementbase.py
+++ b/ufl/finiteelement/finiteelementbase.py
@@ -220,4 +220,5 @@ class FiniteElementBase(ABC):
         if index in ("facet", "interior"):
             from ufl.finiteelement import RestrictedElement
             return RestrictedElement(self, index)
-        return NotImplemented
+        else:
+            raise KeyError(f"Invalid index for restriction: {repr(index)}")

--- a/ufl/finiteelement/finiteelementbase.py
+++ b/ufl/finiteelement/finiteelementbase.py
@@ -222,3 +222,6 @@ class FiniteElementBase(ABC):
             return RestrictedElement(self, index)
         else:
             raise KeyError(f"Invalid index for restriction: {repr(index)}")
+
+    def __iter__(self):
+        raise TypeError(f"'{type(self).__name__}' object is not iterable")


### PR DESCRIPTION
Addresses https://github.com/FEniCS/ufl/issues/179. This changes makes `FiniteElementBase` raise an error when `__iter__` is called, so that Python does not treat it as an iterable object.

In addition, it appears that the use of `NotImplemented` in `FiniteElementBase.__getitem__` may be inappropriate since (I think) `__getitem__` is not one of the binary operations [for which `NotImplemented` is intended](https://docs.python.org/3/library/constants.html#NotImplemented), so it is replaced with a `KeyError` when an invalid restriction is supplied.