### PR TITLE
Deprecated ways of defining coefficients removed

### DIFF
--- a/ufl/argument.py
+++ b/ufl/argument.py
@@ -17,7 +17,7 @@ from ufl.core.ufl_type import ufl_type
 from ufl.core.terminal import FormArgument
 from ufl.split_functions import split
 from ufl.form import BaseForm
-from ufl.functionspace import AbstractFunctionSpace, MixedFunctionSpace
+from ufl.functionspace import MixedFunctionSpace
 from ufl.duals import is_primal, is_dual
 
 # Export list for ufl.classes (TODO: not actually classes: drop? these are in ufl.*)
@@ -35,9 +35,6 @@ class BaseArgument(object):
         return (self._ufl_function_space, self._number, self._part)
 
     def __init__(self, function_space, number, part=None):
-
-        if not isinstance(function_space, AbstractFunctionSpace):
-            raise ValueError("Expecting a FunctionSpace or FiniteElement.")
 
         self._ufl_function_space = function_space
         self._ufl_shape = function_space.ufl_element().value_shape()

--- a/ufl/argument.py
+++ b/ufl/argument.py
@@ -38,13 +38,7 @@ class BaseArgument(object):
 
     def __init__(self, function_space, number, part=None):
 
-        if isinstance(function_space, FiniteElementBase):
-            # For legacy support for UFL files using cells, we map the cell to
-            # the default Mesh
-            element = function_space
-            domain = default_domain(element.cell())
-            function_space = FunctionSpace(domain, element)
-        elif not isinstance(function_space, AbstractFunctionSpace):
+        if not isinstance(function_space, AbstractFunctionSpace):
             raise ValueError("Expecting a FunctionSpace or FiniteElement.")
 
         self._ufl_function_space = function_space

--- a/ufl/argument.py
+++ b/ufl/argument.py
@@ -16,10 +16,8 @@ import numbers
 from ufl.core.ufl_type import ufl_type
 from ufl.core.terminal import FormArgument
 from ufl.split_functions import split
-from ufl.finiteelement import FiniteElementBase
-from ufl.domain import default_domain
 from ufl.form import BaseForm
-from ufl.functionspace import AbstractFunctionSpace, FunctionSpace, MixedFunctionSpace
+from ufl.functionspace import AbstractFunctionSpace, MixedFunctionSpace
 from ufl.duals import is_primal, is_dual
 
 # Export list for ufl.classes (TODO: not actually classes: drop? these are in ufl.*)

--- a/ufl/coefficient.py
+++ b/ufl/coefficient.py
@@ -14,7 +14,7 @@ of related classes, including Constant."""
 
 from ufl.core.ufl_type import ufl_type
 from ufl.core.terminal import FormArgument
-from ufl.functionspace import AbstractFunctionSpace, MixedFunctionSpace
+from ufl.functionspace import MixedFunctionSpace
 from ufl.form import BaseForm
 from ufl.split_functions import split
 from ufl.utils.counted import Counted
@@ -38,9 +38,6 @@ class BaseCoefficient(Counted):
 
     def __init__(self, function_space, count=None):
         Counted.__init__(self, count, Coefficient)
-
-        if not isinstance(function_space, AbstractFunctionSpace):
-            raise ValueError("Expecting a FunctionSpace or FiniteElement.")
 
         self._ufl_function_space = function_space
         self._ufl_shape = function_space.ufl_element().value_shape()

--- a/ufl/coefficient.py
+++ b/ufl/coefficient.py
@@ -41,13 +41,7 @@ class BaseCoefficient(Counted):
     def __init__(self, function_space, count=None):
         Counted.__init__(self, count, Coefficient)
 
-        if isinstance(function_space, FiniteElementBase):
-            # For legacy support for .ufl files using cells, we map
-            # the cell to The Default Mesh
-            element = function_space
-            domain = default_domain(element.cell())
-            function_space = FunctionSpace(domain, element)
-        elif not isinstance(function_space, AbstractFunctionSpace):
+        if not isinstance(function_space, AbstractFunctionSpace):
             raise ValueError("Expecting a FunctionSpace or FiniteElement.")
 
         self._ufl_function_space = function_space

--- a/ufl/coefficient.py
+++ b/ufl/coefficient.py
@@ -14,9 +14,7 @@ of related classes, including Constant."""
 
 from ufl.core.ufl_type import ufl_type
 from ufl.core.terminal import FormArgument
-from ufl.finiteelement import FiniteElementBase
-from ufl.domain import default_domain
-from ufl.functionspace import AbstractFunctionSpace, FunctionSpace, MixedFunctionSpace
+from ufl.functionspace import AbstractFunctionSpace, MixedFunctionSpace
 from ufl.form import BaseForm
 from ufl.split_functions import split
 from ufl.utils.counted import Counted


### PR DESCRIPTION
Two instances where coefficients were defined for old ufl files have been removed. However, there still are methods that handle `legacy_domains`, which could also be remnants of old files. I suggest to review its use, because these might be no longer in use as well.