### PR TITLE
Deprecation messages for legacy features

### DIFF
--- a/ufl/argument.py
+++ b/ufl/argument.py
@@ -47,8 +47,8 @@ class BaseArgument(object):
             element = function_space
             domain = default_domain(element.cell())
             function_space = FunctionSpace(domain, element)
-            warnings.warn("The use of FiniteElement will be deprecated by December 2023. "
-                          "Please, use FunctionSpace instead", DeprecationWarning)
+            warnings.warn("The use of FiniteElement as an input to Argument will be deprecated by December 2023. "
+                          "Please, use FunctionSpace instead", FutureWarning)
         elif not isinstance(function_space, AbstractFunctionSpace):
             raise ValueError("Expecting a FunctionSpace or FiniteElement.")
 

--- a/ufl/argument.py
+++ b/ufl/argument.py
@@ -11,8 +11,11 @@ classes (functions), including TestFunction and TrialFunction."""
 # Modified by Anders Logg, 2008-2009.
 # Modified by Massimiliano Leoni, 2016.
 # Modified by Cecile Daversin-Catty, 2018.
+# Modified by Ignacia Fierro-Piccardo 2023.
 
+import warnings
 import numbers
+
 from ufl.core.ufl_type import ufl_type
 from ufl.core.terminal import FormArgument
 from ufl.split_functions import split
@@ -44,6 +47,8 @@ class BaseArgument(object):
             element = function_space
             domain = default_domain(element.cell())
             function_space = FunctionSpace(domain, element)
+            warnings.warn("The use of FiniteElement will be deprecated by December 2023. "
+                          "Please, use FunctionSpace instead", DeprecationWarning)
         elif not isinstance(function_space, AbstractFunctionSpace):
             raise ValueError("Expecting a FunctionSpace or FiniteElement.")
 

--- a/ufl/coefficient.py
+++ b/ufl/coefficient.py
@@ -50,8 +50,8 @@ class BaseCoefficient(Counted):
             element = function_space
             domain = default_domain(element.cell())
             function_space = FunctionSpace(domain, element)
-            warnings.warn("The use of FiniteElement will be deprecated by December 2023. "
-                          "Please, use FunctionSpace instead", DeprecationWarning)
+            warnings.warn("The use of FiniteElement as an input to Coefficient will be deprecated by December 2023. "
+                          "Please, use FunctionSpace instead", FutureWarning)
         elif not isinstance(function_space, AbstractFunctionSpace):
             raise ValueError("Expecting a FunctionSpace or FiniteElement.")
 

--- a/ufl/coefficient.py
+++ b/ufl/coefficient.py
@@ -11,6 +11,8 @@ of related classes, including Constant."""
 # Modified by Anders Logg, 2008-2009.
 # Modified by Massimiliano Leoni, 2016.
 # Modified by Cecile Daversin-Catty, 2018.
+# Modified by Ignacia Fierro-Piccardo 2023.
+import warnings
 
 from ufl.core.ufl_type import ufl_type
 from ufl.core.terminal import FormArgument
@@ -21,6 +23,7 @@ from ufl.form import BaseForm
 from ufl.split_functions import split
 from ufl.utils.counted import Counted
 from ufl.duals import is_primal, is_dual
+
 
 # --- The Coefficient class represents a coefficient in a form ---
 
@@ -47,6 +50,8 @@ class BaseCoefficient(Counted):
             element = function_space
             domain = default_domain(element.cell())
             function_space = FunctionSpace(domain, element)
+            warnings.warn("The use of FiniteElement will be deprecated by December 2023. "
+                          "Please, use FunctionSpace instead", DeprecationWarning)
         elif not isinstance(function_space, AbstractFunctionSpace):
             raise ValueError("Expecting a FunctionSpace or FiniteElement.")
 

--- a/ufl/domain.py
+++ b/ufl/domain.py
@@ -7,6 +7,7 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
 import numbers
+import warnings
 
 from ufl.cell import AbstractCell, TensorProductCell, as_cell
 from ufl.core.ufl_id import attach_ufl_id
@@ -318,6 +319,8 @@ def join_domains(domains):
 
     # Handle legacy domains checking
     if legacy_domains:
+        warnings.warn("The use of Legacy domains will be deprecated by December 2023. "
+                      "Please, use FunctionSpace instead", DeprecationWarning)
         if modern_domains:
             raise ValueError(
                 "Found both a new-style domain and a legacy default domain. "


### PR DESCRIPTION
Deprecation messages have been introduced when Legacy objects are used. It seems that despite the legacy elements are deprecated, many tests and functions in ufl still use these features. In some cases `FiniteElement` objects are being passed to functions and  are transformed by `arguments.py` and `coefficients.py` to a `FunctionSpace` object. The code should be deprecated in principle by December 2023, but we must review the usage of `FiniteElement` within ufl in order to complete this.