### PR TITLE
convert Atan2 to atan2 not atan_2

### DIFF
--- a/ufl/utils/formatting.py
+++ b/ufl/utils/formatting.py
@@ -11,7 +11,7 @@ def camel2underscore(name):
     letters = []
     lastlower = False
     for i in name:
-        thislower = i.islower()
+        thislower = i.islower() or i.isdigit()
         if not thislower:
             # Don't insert _ between multiple upper case letters
             if lastlower:


### PR DESCRIPTION
I think this fix is safe because `atan2` is the only case of a UFL symbol containing a digit. Thanks to @angus-g