### PR TITLE
We do require pip>=22.3 for editable installs (PEP 660).

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=62", "wheel"]
+requires = ["setuptools>=62", "wheel", "pip>=22.3"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
This does not quite resolve issues with users trying to install with an outdated pip version, as the upgrade happens at runtime, and doesn't change the current version of pip that is executed. PEP 660: https://peps.python.org/pep-0660/

