### PR TITLE
`topological_sorting`: replace ineffective `continue` with `break`

### DIFF
--- a/ufl/utils/sorting.py
+++ b/ufl/utils/sorting.py
@@ -22,7 +22,7 @@ def topological_sorting(nodes, edges):
         for es in edges.values():
             if node in es and node in S:
                 S.remove(node)
-                continue
+                break
 
     while S:
         node = S.pop(0)


### PR DESCRIPTION
# Description of issue

The `continue` statement in `ufl.utils.sorting.topological_sorting` (https://github.com/FEniCS/ufl/blob/main/ufl/utils/sorting.py#L25) has no effect: it causes execution to jump to the beginning of the inner `for` loop, which would happen anyway since there is no code following the `continue` inside the loop. It should be a `break` statement, since there is no need to continue searching the edges once `node` has been removed from `S`.

# Description of changes

This pull request replaces the offending `continue` with a `break`.