### PR TITLE
Fix isort section in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,5 +48,5 @@ packages = [
 [tool.pydocstyle]
 convention = "google"
 
-[itool.sort]
+[tool.isort]
 line_length = 120


### PR DESCRIPTION
Seems a typo to me.