### PR TITLE
ufl2unicode fail 

### DIFF
--- a/ufl/formatting/ufl2unicode.py
+++ b/ufl/formatting/ufl2unicode.py
@@ -303,7 +303,7 @@ def get_integral_symbol(integral_type, domain, subdomain_id):
     subdomain_strs = []
     for subdomain in subdomain_id:
         if isinstance(subdomain, numbers.Integral):
-            subdomain_strs.append(subscript_number(int(subdomain_id)))
+            subdomain_strs.append(subscript_number(int(subdomain)))
         elif subdomain_id == "everywhere":
             pass
         elif subdomain_id == "otherwise":

--- a/ufl/formatting/ufl2unicode.py
+++ b/ufl/formatting/ufl2unicode.py
@@ -304,7 +304,7 @@ def get_integral_symbol(integral_type, domain, subdomain_id):
     for subdomain in subdomain_id:
         if isinstance(subdomain, numbers.Integral):
             subdomain_strs.append(subscript_number(int(subdomain)))
-        elif subdomain_id == "everywhere":
+        elif subdomain == "everywhere":
             pass
         elif subdomain_id == "otherwise":
             subdomain_strs.append("[rest of domain]")

--- a/ufl/formatting/ufl2unicode.py
+++ b/ufl/formatting/ufl2unicode.py
@@ -308,7 +308,7 @@ def get_integral_symbol(integral_type, domain, subdomain_id):
             pass
         elif subdomain_id == "otherwise":
             subdomain_strs.append("[rest of domain]")
-        istr += ",".join(subdomain_strs)
+    istr += ",".join(subdomain_strs)
 
     dxstr = ufl.measure.integral_type_to_measure_name[integral_type]
     dxstr = measure_font(dxstr)

--- a/ufl/formatting/ufl2unicode.py
+++ b/ufl/formatting/ufl2unicode.py
@@ -300,14 +300,15 @@ def get_integral_symbol(integral_type, domain, subdomain_id):
 
     # TODO: Render domain description
 
-    if isinstance(subdomain_id, numbers.Integral):
-        istr += subscript_number(int(subdomain_id))
-    elif subdomain_id == "everywhere":
-        pass
-    elif subdomain_id == "otherwise":
-        istr += "[rest of domain]"
-    elif isinstance(subdomain_id, tuple):
-        istr += ",".join([subscript_number(int(i)) for i in subdomain_id])
+    subdomain_strs = []
+    for subdomain in subdomain_id:
+        if isinstance(subdomain, numbers.Integral):
+            subdomain_strs.append(subscript_number(int(subdomain_id)))
+        elif subdomain_id == "everywhere":
+            pass
+        elif subdomain_id == "otherwise":
+            subdomain_strs.append("[rest of domain]")
+        istr += ",".join(subdomain_strs)
 
     dxstr = ufl.measure.integral_type_to_measure_name[integral_type]
     dxstr = measure_font(dxstr)

--- a/ufl/formatting/ufl2unicode.py
+++ b/ufl/formatting/ufl2unicode.py
@@ -306,7 +306,7 @@ def get_integral_symbol(integral_type, domain, subdomain_id):
             subdomain_strs.append(subscript_number(int(subdomain)))
         elif subdomain == "everywhere":
             pass
-        elif subdomain_id == "otherwise":
+        elif subdomain == "otherwise":
             subdomain_strs.append("[rest of domain]")
     istr += ",".join(subdomain_strs)
 


### PR DESCRIPTION
In a recent change to UFL, `subdomain_id` was transformed from a single value to a tuple. This broke some assumptions in ufl2unicode that I have fixed here.