### PR TITLE
Update OMPI environment variables in FEniCSx integration test for openmpi v5

### DIFF
--- a/.github/workflows/fenicsx-tests.yml
+++ b/.github/workflows/fenicsx-tests.yml
@@ -59,11 +59,6 @@ jobs:
       PETSC_ARCH: linux-gnu-complex128-32
       OMPI_ALLOW_RUN_AS_ROOT: 1
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
-      OMPI_MCA_rmaps_base_oversubscribe: 1
-      OMPI_MCA_plm: isolated
-      OMPI_MCA_btl_vader_single_copy_mechanism: none
-      OMPI_MCA_mpi_yield_when_idle: 1
-      OMPI_MCA_hwloc_base_binding_policy: none
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
I cannot see any test being actually run in parallel there, but it's probably better to clean up those variables anyway, consistently with https://github.com/FEniCS/dolfinx/pull/2865 https://github.com/FEniCS/ffcx/pull/638 https://github.com/FEniCS/basix/pull/739