### PR TITLE
`FormSum.coefficients` should be ordered deterministically the same as `Form.coefficients`

### DIFF
--- a/ufl/form.py
+++ b/ufl/form.py
@@ -784,8 +784,11 @@ class FormSum(BaseForm):
         for component in self._components:
             arguments.extend(component.arguments())
             coefficients.extend(component.coefficients())
-        self._arguments = tuple(set(arguments))
-        self._coefficients = tuple(set(coefficients))
+        # Define canonical numbering of arguments and coefficients
+        self._arguments = tuple(
+            sorted(set(arguments), key=lambda x: x.number()))
+        self._coefficients = tuple(
+            sorted(set(coefficients), key=lambda x: x.count()))
 
     def _analyze_domains(self):
         """Analyze which domains can be found in FormSum."""


### PR DESCRIPTION
`Form.coefficients()` and `FormSum.coefficients()` both use `set` to produce a unique collection of the coefficients. However, `set` does not have deterministic ordering. `Form._analyze_form_arguments()` uses `sorted` to make sure that the ordering is deterministic across MPI ranks and across multiple programme executions, but `FormSum._analyze_form_arguments()` doesn't.

This means that the ordering is sometimes different between different MPI ranks, which causes parallel hangs in MG code when a `Function` is sent to `inject` on one rank and a `Cofunction` is sent to `restrict` on another rank.

This PR just adds orders `FormSum.coefficients()` in the same way as `Form.coefficients()`