### PR TITLE
Update apply_restrictions

### DIFF
--- a/ufl/action.py
+++ b/ufl/action.py
@@ -8,7 +8,6 @@
 # Modified by Nacime Bouziani, 2021-2022.
 
 import typing
-from ufl.typing import Self
 from itertools import chain
 
 from ufl.algebra import Sum
@@ -20,6 +19,7 @@ from ufl.core.ufl_type import ufl_type
 from ufl.differentiation import CoefficientDerivative
 from ufl.form import BaseForm, Form, FormSum, ZeroBaseForm
 from ufl.matrix import Matrix
+from ufl.typing import Self
 
 # --- The Action class represents the action of a numerical object that needs
 #     to be computed at assembly time ---

--- a/ufl/action.py
+++ b/ufl/action.py
@@ -7,6 +7,8 @@
 #
 # Modified by Nacime Bouziani, 2021-2022.
 
+import typing
+from ufl.typing import Self
 from itertools import chain
 
 from ufl.algebra import Sum
@@ -149,6 +151,13 @@ class Action(BaseForm):
         if self._hash is None:
             self._hash = hash(("Action", hash(self._right), hash(self._left)))
         return self._hash
+
+    def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
+        """Apply restrictions.
+
+        Propagates restrictions in a form towards the terminals.
+        """
+        return Action(self._left.apply_restrictions(side), self._right.apply_restrictions(side))
 
 
 def _check_function_spaces(left, right):

--- a/ufl/adjoint.py
+++ b/ufl/adjoint.py
@@ -9,10 +9,11 @@
 # Modified by Nacime Bouziani, 2021-2022.
 
 import typing
-from ufl.typing import Self
+
 from ufl.argument import Coargument
 from ufl.core.ufl_type import ufl_type
 from ufl.form import BaseForm, FormSum, ZeroBaseForm
+from ufl.typing import Self
 
 # --- The Adjoint class represents the adjoint of a numerical object that
 #     needs to be computed at assembly time ---

--- a/ufl/adjoint.py
+++ b/ufl/adjoint.py
@@ -8,6 +8,8 @@
 #
 # Modified by Nacime Bouziani, 2021-2022.
 
+import typing
+from ufl.typing import Self
 from ufl.argument import Coargument
 from ufl.core.ufl_type import ufl_type
 from ufl.form import BaseForm, FormSum, ZeroBaseForm
@@ -119,3 +121,10 @@ class Adjoint(BaseForm):
         if self._hash is None:
             self._hash = hash(("Adjoint", hash(self._form)))
         return self._hash
+
+    def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
+        """Apply restrictions.
+
+        Propagates restrictions in a form towards the terminals.
+        """
+        return Adjoint(self._form.apply_restrictions(side))

--- a/ufl/algorithms/apply_restrictions.py
+++ b/ufl/algorithms/apply_restrictions.py
@@ -10,11 +10,11 @@ restrictions in a form towards the terminals.
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 import typing
-import warnings
 from abc import abstractmethod
 from typing import Protocol
 
 from ufl.algorithms.map_integrands import map_integrand_dags
+from ufl.core import caching
 from ufl.corealg.multifunction import MultiFunction
 from ufl.measure import integral_type_to_measure_name
 from ufl.typing import Self
@@ -36,12 +36,10 @@ default_restriction = "+"
 
 def apply_restrictions(expression: ApplyRestrictions):
     """Propagate restriction nodes to wrap differential terminals directly."""
-    warnings.warn(
-        "apply_restrictions(expression) is deprecated and will be removed "
-        "after December 2024. Please, use expression.apply_restrictions() instead",
-        FutureWarning,
-    )
-    return expression.apply_restrictions()
+    caching.initialise_cache("apply_restrictions")
+    result = expression.apply_restrictions()
+    caching.clear_cache("apply_restrictions")
+    return result
 
 
 class DefaultRestrictionApplier(MultiFunction):

--- a/ufl/argument.py
+++ b/ufl/argument.py
@@ -15,6 +15,7 @@ classes (functions), including TestFunction and TrialFunction.
 # Modified by Ignacia Fierro-Piccardo 2023.
 
 import numbers
+import typing
 
 from ufl.core.terminal import FormArgument
 from ufl.core.ufl_type import ufl_type
@@ -42,7 +43,7 @@ class BaseArgument(object):
         return (self._ufl_function_space, self._number, self._part)
 
     def __init__(self, function_space, number, part=None):
-        """initialise."""
+        """Initialise."""
         if not isinstance(function_space, AbstractFunctionSpace):
             raise ValueError("Expecting a FunctionSpace.")
 
@@ -190,13 +191,13 @@ class Argument(FormArgument, BaseArgument):
         """Representation."""
         return self._repr
 
-    def apply_restrictions(self, side: typing.Optional[Str] = None) -> Self:
+    def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 
         Propagates restrictions in a form towards the terminals.
         """
         if side is None:
-            raise ValueError(f"Discontinuous type {o._ufl_class_.__name__} must be restricted.")
+            raise ValueError(f"Discontinuous type {self.__class__.__name__} must be restricted.")
         return self(side)
 
 

--- a/ufl/argument.py
+++ b/ufl/argument.py
@@ -14,6 +14,7 @@ classes (functions), including TestFunction and TrialFunction.
 # Modified by Cecile Daversin-Catty, 2018.
 # Modified by Ignacia Fierro-Piccardo 2023.
 
+import functools
 import numbers
 import typing
 
@@ -191,6 +192,7 @@ class Argument(FormArgument, BaseArgument):
         """Representation."""
         return self._repr
 
+    @functools.lru_cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 

--- a/ufl/argument.py
+++ b/ufl/argument.py
@@ -14,10 +14,10 @@ classes (functions), including TestFunction and TrialFunction.
 # Modified by Cecile Daversin-Catty, 2018.
 # Modified by Ignacia Fierro-Piccardo 2023.
 
-import functools
 import numbers
 import typing
 
+from ufl.core.caching import cache
 from ufl.core.terminal import FormArgument
 from ufl.core.ufl_type import ufl_type
 from ufl.duals import is_dual, is_primal
@@ -192,7 +192,7 @@ class Argument(FormArgument, BaseArgument):
         """Representation."""
         return self._repr
 
-    @functools.lru_cache
+    @cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 

--- a/ufl/argument.py
+++ b/ufl/argument.py
@@ -22,6 +22,7 @@ from ufl.duals import is_dual, is_primal
 from ufl.form import BaseForm
 from ufl.functionspace import AbstractFunctionSpace, MixedFunctionSpace
 from ufl.split_functions import split
+from ufl.typing import Self
 
 # Export list for ufl.classes (TODO: not actually classes: drop? these are in ufl.*)
 __all_classes__ = ["TestFunction", "TrialFunction", "TestFunctions", "TrialFunctions"]
@@ -188,6 +189,15 @@ class Argument(FormArgument, BaseArgument):
     def __repr__(self):
         """Representation."""
         return self._repr
+
+    def apply_restrictions(self, side: typing.Optional[Str] = None) -> Self:
+        """Apply restrictions.
+
+        Propagates restrictions in a form towards the terminals.
+        """
+        if side is None:
+            raise ValueError(f"Discontinuous type {o._ufl_class_.__name__} must be restricted.")
+        return self(side)
 
 
 @ufl_type()

--- a/ufl/coefficient.py
+++ b/ufl/coefficient.py
@@ -10,6 +10,7 @@
 # Modified by Massimiliano Leoni, 2016.
 # Modified by Cecile Daversin-Catty, 2018.
 # Modified by Ignacia Fierro-Piccardo 2023.
+import typing
 
 from ufl.argument import Argument
 from ufl.core.terminal import FormArgument
@@ -17,7 +18,9 @@ from ufl.core.ufl_type import ufl_type
 from ufl.duals import is_dual, is_primal
 from ufl.form import BaseForm
 from ufl.functionspace import AbstractFunctionSpace, MixedFunctionSpace
+from ufl.sobolevspace import H1
 from ufl.split_functions import split
+from ufl.typing import Self
 from ufl.utils.counted import Counted
 
 # --- The Coefficient class represents a coefficient in a form ---
@@ -199,6 +202,25 @@ class Coefficient(FormArgument, BaseCoefficient):
     def __repr__(self):
         """Representation."""
         return self._repr
+
+    def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
+        """Apply restrictions.
+
+        Propagates restrictions in a form towards the terminals.
+        """
+        from ufl.algorithms.apply_restrictions import default_restriction
+
+        if self.ufl_element() in H1:
+            if side is None:
+                return self(default_restriction)
+            else:
+                return self(side)
+        else:
+            if side is None:
+                raise ValueError(
+                    f"Discontinuous type {self.__class__.__name__} must be restricted."
+                )
+            return self(side)
 
 
 # --- Helper functions for subfunctions on mixed elements ---

--- a/ufl/coefficient.py
+++ b/ufl/coefficient.py
@@ -10,6 +10,7 @@
 # Modified by Massimiliano Leoni, 2016.
 # Modified by Cecile Daversin-Catty, 2018.
 # Modified by Ignacia Fierro-Piccardo 2023.
+import functools
 import typing
 
 from ufl.argument import Argument
@@ -203,6 +204,7 @@ class Coefficient(FormArgument, BaseCoefficient):
         """Representation."""
         return self._repr
 
+    @functools.lru_cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 

--- a/ufl/coefficient.py
+++ b/ufl/coefficient.py
@@ -10,10 +10,10 @@
 # Modified by Massimiliano Leoni, 2016.
 # Modified by Cecile Daversin-Catty, 2018.
 # Modified by Ignacia Fierro-Piccardo 2023.
-import functools
 import typing
 
 from ufl.argument import Argument
+from ufl.core.caching import cache
 from ufl.core.terminal import FormArgument
 from ufl.core.ufl_type import ufl_type
 from ufl.duals import is_dual, is_primal
@@ -204,7 +204,7 @@ class Coefficient(FormArgument, BaseCoefficient):
         """Representation."""
         return self._repr
 
-    @functools.lru_cache
+    @cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 

--- a/ufl/constant.py
+++ b/ufl/constant.py
@@ -6,9 +6,12 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
+import typing
+
 from ufl.core.terminal import Terminal
 from ufl.core.ufl_type import ufl_type
 from ufl.domain import as_domain
+from ufl.typing import Self
 from ufl.utils.counted import Counted
 
 
@@ -76,6 +79,13 @@ class Constant(Terminal, Counted):
             repr(self._ufl_shape),
             repr(renumbering[self]),
         )
+
+    def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
+        """Apply restrictions.
+
+        Propagates restrictions in a form towards the terminals.
+        """
+        return self
 
 
 def VectorConstant(domain, count=None):

--- a/ufl/constant.py
+++ b/ufl/constant.py
@@ -6,9 +6,9 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
-import functools
 import typing
 
+from ufl.core.caching import cache
 from ufl.core.terminal import Terminal
 from ufl.core.ufl_type import ufl_type
 from ufl.domain import as_domain
@@ -81,7 +81,7 @@ class Constant(Terminal, Counted):
             repr(renumbering[self]),
         )
 
-    @functools.lru_cache
+    @cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 

--- a/ufl/constant.py
+++ b/ufl/constant.py
@@ -6,6 +6,7 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
+import functools
 import typing
 
 from ufl.core.terminal import Terminal
@@ -80,6 +81,7 @@ class Constant(Terminal, Counted):
             repr(renumbering[self]),
         )
 
+    @functools.lru_cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 

--- a/ufl/constantvalue.py
+++ b/ufl/constantvalue.py
@@ -9,6 +9,7 @@
 # Modified by Anders Logg, 2011.
 # Modified by Massimiliano Leoni, 2016.
 
+import functools
 import typing
 from math import atan2
 
@@ -55,6 +56,7 @@ class ConstantValue(Terminal):
         """Return tuple of domains related to this terminal object."""
         return ()
 
+    @functools.lru_cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 

--- a/ufl/constantvalue.py
+++ b/ufl/constantvalue.py
@@ -9,14 +9,12 @@
 # Modified by Anders Logg, 2011.
 # Modified by Massimiliano Leoni, 2016.
 
-import functools
 import typing
 from math import atan2
 
 import ufl
-
-# --- Helper functions imported here for compatibility---
 from ufl.checks import is_python_scalar, is_true_ufl_scalar, is_ufl_scalar  # noqa: F401
+from ufl.core.caching import cache
 from ufl.core.expr import Expr
 from ufl.core.multiindex import FixedIndex, Index
 from ufl.core.terminal import Terminal
@@ -56,7 +54,7 @@ class ConstantValue(Terminal):
         """Return tuple of domains related to this terminal object."""
         return ()
 
-    @functools.lru_cache
+    @cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 

--- a/ufl/constantvalue.py
+++ b/ufl/constantvalue.py
@@ -9,6 +9,7 @@
 # Modified by Anders Logg, 2011.
 # Modified by Massimiliano Leoni, 2016.
 
+import typing
 from math import atan2
 
 import ufl
@@ -19,6 +20,7 @@ from ufl.core.expr import Expr
 from ufl.core.multiindex import FixedIndex, Index
 from ufl.core.terminal import Terminal
 from ufl.core.ufl_type import ufl_type
+from ufl.typing import Self
 
 # Precision for float formatting
 precision = None
@@ -52,6 +54,13 @@ class ConstantValue(Terminal):
     def ufl_domains(self):
         """Return tuple of domains related to this terminal object."""
         return ()
+
+    def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
+        """Apply restrictions.
+
+        Propagates restrictions in a form towards the terminals.
+        """
+        return self
 
 
 # TODO: Add geometric dimension/domain and Argument dependencies to Zero?

--- a/ufl/core/caching.py
+++ b/ufl/core/caching.py
@@ -27,7 +27,7 @@ def initialise_cache(function_name: str):
     __cache[function_name] = {}
 
 
-def empty_cache(function_name: str):
+def clear_cache(function_name: str):
     """Remove the cache for a given function."""
     global __cache
     del __cache[function_name]

--- a/ufl/core/caching.py
+++ b/ufl/core/caching.py
@@ -22,7 +22,7 @@ def cache(f):
 
 
 def initialise_cache(function_name: str):
-    """Initialise a cacge for a given function."""
+    """Initialise a cache for a given function."""
     global __cache
     __cache[function_name] = {}
 

--- a/ufl/core/caching.py
+++ b/ufl/core/caching.py
@@ -1,0 +1,33 @@
+"""Caching.
+
+Custom caching function to be used with class methods.
+"""
+
+__cache = {}
+
+
+def cache(f):
+    """Decorator for caching the result of a function."""
+
+    def cached_f(self, *args, **kwargs):
+        global __cache
+        key = f"{args} {kwargs}"
+        if self not in __cache[f.__name__]:
+            __cache[f.__name__][self] = {}
+        if key not in __cache[f.__name__][self]:
+            __cache[f.__name__][self][key] = f(self, *args, **kwargs)
+        return __cache[f.__name__][self][key]
+
+    return cached_f
+
+
+def initialise_cache(function_name: str):
+    """Initialise a cacge for a given function."""
+    global __cache
+    __cache[function_name] = {}
+
+
+def empty_cache(function_name: str):
+    """Remove the cache for a given function."""
+    global __cache
+    del __cache[function_name]

--- a/ufl/core/caching.py
+++ b/ufl/core/caching.py
@@ -2,6 +2,13 @@
 
 Custom caching function to be used with class methods.
 """
+
+# Copyright (C) 2024 Matthew Scroggs
+#
+# This file is part of UFL (https://www.fenicsproject.org)
+#
+# SPDX-License-Identifier:    LGPL-3.0-or-later
+
 import typing
 
 __cache: typing.Dict[str, typing.Dict[typing.Any, typing.Dict[str, typing.Any]]] = {}

--- a/ufl/core/caching.py
+++ b/ufl/core/caching.py
@@ -2,11 +2,12 @@
 
 Custom caching function to be used with class methods.
 """
+import typing
 
-__cache = {}
+__cache: typing.Dict[str, typing.Dict[typing.Any, typing.Dict[str, typing.Any]]] = {}
 
 
-def cache(f):
+def cache(f: typing.Callable) -> typing.Callable:
     """Decorator for caching the result of a function."""
 
     def cached_f(self, *args, **kwargs):
@@ -18,6 +19,7 @@ def cache(f):
             __cache[f.__name__][self][key] = f(self, *args, **kwargs)
         return __cache[f.__name__][self][key]
 
+    cached_f.__doc__ = f.__doc__
     return cached_f
 
 

--- a/ufl/core/multiindex.py
+++ b/ufl/core/multiindex.py
@@ -8,6 +8,7 @@
 #
 # Modified by Massimiliano Leoni, 2016.
 
+import functools
 import typing
 
 from ufl.core.terminal import Terminal
@@ -258,6 +259,7 @@ class MultiIndex(Terminal):
         """Return iteratable."""
         return iter(self._indices)
 
+    @functools.lru_cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 

--- a/ufl/core/multiindex.py
+++ b/ufl/core/multiindex.py
@@ -8,9 +8,9 @@
 #
 # Modified by Massimiliano Leoni, 2016.
 
-import functools
 import typing
 
+from ufl.core.caching import cache
 from ufl.core.terminal import Terminal
 from ufl.core.ufl_type import ufl_type
 from ufl.typing import Self
@@ -259,7 +259,7 @@ class MultiIndex(Terminal):
         """Return iteratable."""
         return iter(self._indices)
 
-    @functools.lru_cache
+    @cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 

--- a/ufl/core/multiindex.py
+++ b/ufl/core/multiindex.py
@@ -8,8 +8,11 @@
 #
 # Modified by Massimiliano Leoni, 2016.
 
+import typing
+
 from ufl.core.terminal import Terminal
 from ufl.core.ufl_type import ufl_type
+from ufl.typing import Self
 from ufl.utils.counted import Counted
 
 # Export list for ufl.classes
@@ -254,6 +257,13 @@ class MultiIndex(Terminal):
     def __iter__(self):
         """Return iteratable."""
         return iter(self._indices)
+
+    def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
+        """Apply restrictions.
+
+        Propagates restrictions in a form towards the terminals.
+        """
+        return self
 
 
 def indices(n):

--- a/ufl/core/operator.py
+++ b/ufl/core/operator.py
@@ -8,9 +8,9 @@
 # Modified by Anders Logg, 2008
 # Modified by Massimiliano Leoni, 2016
 
-import functools
 import typing
 
+from ufl.core.caching import cache
 from ufl.core.expr import Expr
 from ufl.core.ufl_type import ufl_type
 from ufl.typing import Self
@@ -50,7 +50,7 @@ class Operator(Expr):
         # This should work for most cases
         return f"{self._ufl_class_.__name__}({', '.join(repr(op) for op in self.ufl_operands)})"
 
-    @functools.lru_cache
+    @cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 

--- a/ufl/core/operator.py
+++ b/ufl/core/operator.py
@@ -10,6 +10,7 @@
 
 from ufl.core.expr import Expr
 from ufl.core.ufl_type import ufl_type
+from ufl.typing import Self
 
 
 @ufl_type(is_abstract=True, is_terminal=False)
@@ -45,3 +46,14 @@ class Operator(Expr):
         """Default repr string construction for operators."""
         # This should work for most cases
         return f"{self._ufl_class_.__name__}({', '.join(repr(op) for op in self.ufl_operands)})"
+
+    def apply_restrictions(self, side: typing.Optional[Str] = None) -> Self:
+        """Apply restrictions.
+
+        Propagates restrictions in a form towards the terminals.
+        """
+        ops = [i.apply_restrictions(side) for i in self.ufl_operands]
+        if all(a is b for a, b in zip(self.ufl_operands, ops)):
+            return self
+        else:
+            return self.__class__(*ops)

--- a/ufl/core/operator.py
+++ b/ufl/core/operator.py
@@ -8,6 +8,7 @@
 # Modified by Anders Logg, 2008
 # Modified by Massimiliano Leoni, 2016
 
+import functools
 import typing
 
 from ufl.core.expr import Expr
@@ -49,6 +50,7 @@ class Operator(Expr):
         # This should work for most cases
         return f"{self._ufl_class_.__name__}({', '.join(repr(op) for op in self.ufl_operands)})"
 
+    @functools.lru_cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 

--- a/ufl/core/operator.py
+++ b/ufl/core/operator.py
@@ -8,6 +8,8 @@
 # Modified by Anders Logg, 2008
 # Modified by Massimiliano Leoni, 2016
 
+import typing
+
 from ufl.core.expr import Expr
 from ufl.core.ufl_type import ufl_type
 from ufl.typing import Self
@@ -47,7 +49,7 @@ class Operator(Expr):
         # This should work for most cases
         return f"{self._ufl_class_.__name__}({', '.join(repr(op) for op in self.ufl_operands)})"
 
-    def apply_restrictions(self, side: typing.Optional[Str] = None) -> Self:
+    def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 
         Propagates restrictions in a form towards the terminals.

--- a/ufl/core/terminal.py
+++ b/ufl/core/terminal.py
@@ -16,8 +16,6 @@ import warnings
 from ufl.core.expr import Expr
 from ufl.core.ufl_type import ufl_type
 
-# from ufl.algorithms.apply_restrictions import ApplyRestrictions
-
 
 @ufl_type(is_abstract=True, is_terminal=True)
 class Terminal(Expr):

--- a/ufl/core/terminal.py
+++ b/ufl/core/terminal.py
@@ -16,9 +16,12 @@ import warnings
 from ufl.core.expr import Expr
 from ufl.core.ufl_type import ufl_type
 
+# from ufl.algorithms.apply_restrictions import ApplyRestrictions
+
 
 @ufl_type(is_abstract=True, is_terminal=True)
 class Terminal(Expr):
+    # class Terminal(Expr, ApplyRestrictions):
     """Base class for terminal objects.
 
     A terminal node in the UFL expression tree.

--- a/ufl/differentiation.py
+++ b/ufl/differentiation.py
@@ -6,7 +6,6 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
-import functools
 import typing
 
 from ufl.argument import Argument, Coargument
@@ -14,6 +13,7 @@ from ufl.checks import is_cellwise_constant
 from ufl.coefficient import Coefficient
 from ufl.constantvalue import Zero
 from ufl.core.base_form_operator import BaseFormOperator
+from ufl.core.caching import cache
 from ufl.core.expr import Expr
 from ufl.core.operator import Operator
 from ufl.core.terminal import Terminal
@@ -298,7 +298,7 @@ class Grad(CompoundDerivative):
         """Format as a string."""
         return "grad(%s)" % self.ufl_operands[0]
 
-    @functools.lru_cache
+    @cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 

--- a/ufl/differentiation.py
+++ b/ufl/differentiation.py
@@ -6,6 +6,8 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
+import typing
+
 from ufl.argument import Argument, Coargument
 from ufl.checks import is_cellwise_constant
 from ufl.coefficient import Coefficient
@@ -19,8 +21,8 @@ from ufl.domain import extract_unique_domain, find_geometric_dimension
 from ufl.exprcontainers import ExprList, ExprMapping
 from ufl.form import BaseForm
 from ufl.precedence import parstr
-from ufl.variable import Variable
 from ufl.typing import Self
+from ufl.variable import Variable
 
 # --- Basic differentiation objects ---
 
@@ -295,13 +297,13 @@ class Grad(CompoundDerivative):
         """Format as a string."""
         return "grad(%s)" % self.ufl_operands[0]
 
-    def apply_restrictions(self, side: typing.Optional[Str] = None) -> Self:
+    def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 
         Propagates restrictions in a form towards the terminals.
         """
         if side is None:
-            raise ValueError(f"Discontinuous type {o._ufl_class_.__name__} must be restricted.")
+            raise ValueError(f"Discontinuous type {self.__class__.__name__} must be restricted.")
         return self(side)
 
 

--- a/ufl/differentiation.py
+++ b/ufl/differentiation.py
@@ -20,6 +20,7 @@ from ufl.exprcontainers import ExprList, ExprMapping
 from ufl.form import BaseForm
 from ufl.precedence import parstr
 from ufl.variable import Variable
+from ufl.typing import Self
 
 # --- Basic differentiation objects ---
 
@@ -293,6 +294,15 @@ class Grad(CompoundDerivative):
     def __str__(self):
         """Format as a string."""
         return "grad(%s)" % self.ufl_operands[0]
+
+    def apply_restrictions(self, side: typing.Optional[Str] = None) -> Self:
+        """Apply restrictions.
+
+        Propagates restrictions in a form towards the terminals.
+        """
+        if side is None:
+            raise ValueError(f"Discontinuous type {o._ufl_class_.__name__} must be restricted.")
+        return self(side)
 
 
 @ufl_type(

--- a/ufl/differentiation.py
+++ b/ufl/differentiation.py
@@ -6,6 +6,7 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
+import functools
 import typing
 
 from ufl.argument import Argument, Coargument
@@ -297,6 +298,7 @@ class Grad(CompoundDerivative):
         """Format as a string."""
         return "grad(%s)" % self.ufl_operands[0]
 
+    @functools.lru_cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 

--- a/ufl/form.py
+++ b/ufl/form.py
@@ -12,6 +12,7 @@
 # Modified by Jørgen S. Dokken 2023.
 
 import numbers
+import typing
 import warnings
 from collections import defaultdict
 from itertools import chain
@@ -24,6 +25,7 @@ from ufl.core.ufl_type import UFLType, ufl_type
 from ufl.domain import extract_unique_domain, sort_domains
 from ufl.equation import Equation
 from ufl.integral import Integral
+from ufl.typing import Self
 from ufl.utils.counted import Counted
 from ufl.utils.sorting import sorted_by_count
 
@@ -696,6 +698,15 @@ class Form(BaseForm):
         from ufl.algorithms.signature import compute_form_signature
 
         self._signature = compute_form_signature(self, self._compute_renumbering())
+
+    def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
+        """Apply restrictions.
+
+        Propagates restrictions in a form towards the terminals.
+        """
+        mapped_integrals = [i.apply_restrictions(side) for i in self.integrals()]
+        nonzero_integrals = [i for i in mapped_integrals if not isinstance(i, Zero)]
+        return Form(nonzero_integrals)
 
 
 def as_form(form):

--- a/ufl/form.py
+++ b/ufl/form.py
@@ -949,4 +949,3 @@ class ZeroBaseForm(BaseForm):
         Propagates restrictions in a form towards the terminals.
         """
         return ZeroBaseForm(tuple(arg.apply_restrictions(side) for arg in self._arguments))
-

--- a/ufl/geometry.py
+++ b/ufl/geometry.py
@@ -5,6 +5,7 @@
 # This file is part of UFL (https://www.fenicsproject.org)
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
+import functools
 import typing
 
 from ufl.core.terminal import Terminal
@@ -130,6 +131,7 @@ class GeometricCellQuantity(GeometricQuantity):
 
     __slots__ = ()
 
+    @functools.lru_cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 
@@ -146,6 +148,7 @@ class GeometricFacetQuantity(GeometricQuantity):
 
     __slots__ = ()
 
+    @functools.lru_cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 
@@ -263,6 +266,7 @@ class FacetCoordinate(GeometricFacetQuantity):
         t = self._domain.topological_dimension()
         return t <= 1
 
+    @functools.lru_cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 
@@ -723,6 +727,7 @@ class FacetNormal(GeometricFacetQuantity):
         is_piecewise_linear = ce.embedded_superdegree <= 1 and ce in H1
         return is_piecewise_linear and self._domain.ufl_cell().has_simplex_facets()
 
+    @functools.lru_cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 
@@ -802,6 +807,7 @@ class ReferenceCellVolume(GeometricCellQuantity):
     __slots__ = ()
     name = "reference_cell_volume"
 
+    @functools.lru_cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 
@@ -818,6 +824,7 @@ class ReferenceFacetVolume(GeometricFacetQuantity):
     __slots__ = ()
     name = "reference_facet_volume"
 
+    @functools.lru_cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 
@@ -935,6 +942,7 @@ class QuadratureWeight(GeometricQuantity):
         # The weight usually varies with the quadrature points
         return False
 
+    @functools.lru_cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 

--- a/ufl/geometry.py
+++ b/ufl/geometry.py
@@ -10,6 +10,7 @@ from ufl.core.terminal import Terminal
 from ufl.core.ufl_type import ufl_type
 from ufl.domain import as_domain, extract_unique_domain
 from ufl.sobolevspace import H1
+from ufl.typing import Self
 
 """
 Possible coordinate bootstrapping:
@@ -128,12 +129,30 @@ class GeometricCellQuantity(GeometricQuantity):
 
     __slots__ = ()
 
+    def apply_restrictions(self, side: typing.Optional[Str] = None) -> Self:
+        """Apply restrictions.
+
+        Propagates restrictions in a form towards the terminals.
+        """
+        if side is None:
+            raise ValueError(f"Discontinuous type {o._ufl_class_.__name__} must be restricted.")
+        return self(side)
+
 
 @ufl_type(is_abstract=True)
 class GeometricFacetQuantity(GeometricQuantity):
     """Geometric facet quantity."""
 
     __slots__ = ()
+
+    def apply_restrictions(self, side: typing.Optional[Str] = None) -> Self:
+        """Apply restrictions.
+
+        Propagates restrictions in a form towards the terminals.
+        """
+        if side is None:
+            raise ValueError(f"Discontinuous type {o._ufl_class_.__name__} must be restricted.")
+        return self(side)
 
 
 # --- Coordinate represented in different coordinate systems

--- a/ufl/geometry.py
+++ b/ufl/geometry.py
@@ -5,9 +5,9 @@
 # This file is part of UFL (https://www.fenicsproject.org)
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
-import functools
 import typing
 
+from ufl.core.caching import cache
 from ufl.core.terminal import Terminal
 from ufl.core.ufl_type import ufl_type
 from ufl.domain import as_domain, extract_unique_domain
@@ -131,7 +131,7 @@ class GeometricCellQuantity(GeometricQuantity):
 
     __slots__ = ()
 
-    @functools.lru_cache
+    @cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 
@@ -148,7 +148,7 @@ class GeometricFacetQuantity(GeometricQuantity):
 
     __slots__ = ()
 
-    @functools.lru_cache
+    @cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 
@@ -266,7 +266,7 @@ class FacetCoordinate(GeometricFacetQuantity):
         t = self._domain.topological_dimension()
         return t <= 1
 
-    @functools.lru_cache
+    @cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 
@@ -727,7 +727,7 @@ class FacetNormal(GeometricFacetQuantity):
         is_piecewise_linear = ce.embedded_superdegree <= 1 and ce in H1
         return is_piecewise_linear and self._domain.ufl_cell().has_simplex_facets()
 
-    @functools.lru_cache
+    @cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 
@@ -807,7 +807,7 @@ class ReferenceCellVolume(GeometricCellQuantity):
     __slots__ = ()
     name = "reference_cell_volume"
 
-    @functools.lru_cache
+    @cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 
@@ -824,7 +824,7 @@ class ReferenceFacetVolume(GeometricFacetQuantity):
     __slots__ = ()
     name = "reference_facet_volume"
 
-    @functools.lru_cache
+    @cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 
@@ -942,7 +942,7 @@ class QuadratureWeight(GeometricQuantity):
         # The weight usually varies with the quadrature points
         return False
 
-    @functools.lru_cache
+    @cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 

--- a/ufl/integral.py
+++ b/ufl/integral.py
@@ -9,10 +9,13 @@
 # Modified by Anders Logg, 2008-2009
 # Modified by Massimiliano Leoni, 2016.
 
+import typing
+
 import ufl
 from ufl.checks import is_python_scalar, is_scalar_constant_expression
 from ufl.core.expr import Expr
 from ufl.protocols import id_or_none
+from ufl.typing import Self
 
 # Export list for ufl.classes
 __all_classes__ = ["Integral"]
@@ -152,3 +155,13 @@ class Integral(object):
             id_or_none(self._subdomain_data),
         )
         return hash(hashdata)
+
+    def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
+        """Apply restrictions.
+
+        Propagates restrictions in a form towards the terminals.
+        """
+        if self.integral_type().startswith("interior_facet"):
+            return self.reconstruct(self.integrand().apply_restrictions(side))
+        else:
+            return self

--- a/ufl/referencevalue.py
+++ b/ufl/referencevalue.py
@@ -46,7 +46,7 @@ class ReferenceValue(Operator):
 
         Propagates restrictions in a form towards the terminals.
         """
-        (f,) = self._ufl_operands_
+        (f,) = self.ufl_operands
         assert f._ufl_is_terminal_
         g = f.apply_restrictions(side)
         if isinstance(g, Restricted):

--- a/ufl/referencevalue.py
+++ b/ufl/referencevalue.py
@@ -5,6 +5,7 @@
 # This file is part of UFL (https://www.fenicsproject.org)
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
+import functools
 import typing
 
 from ufl.core.operator import Operator
@@ -39,6 +40,7 @@ class ReferenceValue(Operator):
         """Format as a string."""
         return f"reference_value({self.ufl_operands[0]})"
 
+    @functools.lru_cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 

--- a/ufl/referencevalue.py
+++ b/ufl/referencevalue.py
@@ -1,13 +1,17 @@
 """Representation of the reference value of a function."""
+
 # Copyright (C) 2008-2016 Martin Sandve Alnæs
 #
 # This file is part of UFL (https://www.fenicsproject.org)
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
+import typing
 
 from ufl.core.operator import Operator
 from ufl.core.terminal import FormArgument
 from ufl.core.ufl_type import ufl_type
+from ufl.restriction import Restricted
+from ufl.typing import Self
 
 
 @ufl_type(num_ops=1, is_index_free=True, is_terminal_modifier=True, is_in_reference_frame=True)
@@ -34,3 +38,17 @@ class ReferenceValue(Operator):
     def __str__(self):
         """Format as a string."""
         return f"reference_value({self.ufl_operands[0]})"
+
+    def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
+        """Apply restrictions.
+
+        Propagates restrictions in a form towards the terminals.
+        """
+        (f,) = self._ufl_operands_
+        assert f._ufl_is_terminal_
+        g = f.apply_restrictions(side)
+        if isinstance(g, Restricted):
+            side = g.side()
+            return self(side)
+        else:
+            return self

--- a/ufl/referencevalue.py
+++ b/ufl/referencevalue.py
@@ -5,9 +5,9 @@
 # This file is part of UFL (https://www.fenicsproject.org)
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
-import functools
 import typing
 
+from ufl.core.caching import cache
 from ufl.core.operator import Operator
 from ufl.core.terminal import FormArgument
 from ufl.core.ufl_type import ufl_type
@@ -40,7 +40,7 @@ class ReferenceValue(Operator):
         """Format as a string."""
         return f"reference_value({self.ufl_operands[0]})"
 
-    @functools.lru_cache
+    @cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 

--- a/ufl/restriction.py
+++ b/ufl/restriction.py
@@ -1,9 +1,11 @@
 """Restriction operations."""
+
 # Copyright (C) 2008-2016 Martin Sandve Alnæs
 #
 # This file is part of UFL (https://www.fenicsproject.org)
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
+import typing
 
 from ufl.core.operator import Operator
 from ufl.core.ufl_type import ufl_type
@@ -43,14 +45,14 @@ class Restricted(Operator):
         """Format as a string."""
         return f"{parstr(self.ufl_operands[0], self)}({self._side})"
 
-    def apply_restrictions(self, side: typing.Optional[Str] = None) -> Self:
+    def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 
         Propagates restrictions in a form towards the terminals.
         """
         if side is not None:
             raise ValueError("Cannot restrict an expression twice.")
-        return self.__class__(self.ufl_operands[0].apply_restrictions(self._side))
+        return self.ufl_operands[0].apply_restrictions(self._side)
 
 
 @ufl_type(is_terminal_modifier=True)

--- a/ufl/restriction.py
+++ b/ufl/restriction.py
@@ -5,6 +5,7 @@
 # This file is part of UFL (https://www.fenicsproject.org)
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
+import functools
 import typing
 
 from ufl.core.operator import Operator
@@ -45,6 +46,7 @@ class Restricted(Operator):
         """Format as a string."""
         return f"{parstr(self.ufl_operands[0], self)}({self._side})"
 
+    @functools.lru_cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 

--- a/ufl/restriction.py
+++ b/ufl/restriction.py
@@ -5,9 +5,9 @@
 # This file is part of UFL (https://www.fenicsproject.org)
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
-import functools
 import typing
 
+from ufl.core.caching import cache
 from ufl.core.operator import Operator
 from ufl.core.ufl_type import ufl_type
 from ufl.precedence import parstr
@@ -46,7 +46,7 @@ class Restricted(Operator):
         """Format as a string."""
         return f"{parstr(self.ufl_operands[0], self)}({self._side})"
 
-    @functools.lru_cache
+    @cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 

--- a/ufl/restriction.py
+++ b/ufl/restriction.py
@@ -8,6 +8,7 @@
 from ufl.core.operator import Operator
 from ufl.core.ufl_type import ufl_type
 from ufl.precedence import parstr
+from ufl.typing import Self
 
 # --- Restriction operators ---
 
@@ -41,6 +42,15 @@ class Restricted(Operator):
     def __str__(self):
         """Format as a string."""
         return f"{parstr(self.ufl_operands[0], self)}({self._side})"
+
+    def apply_restrictions(self, side: typing.Optional[Str] = None) -> Self:
+        """Apply restrictions.
+
+        Propagates restrictions in a form towards the terminals.
+        """
+        if side is not None:
+            raise ValueError("Cannot restrict an expression twice.")
+        return self.__class__(self.ufl_operands[0].apply_restrictions(self._side))
 
 
 @ufl_type(is_terminal_modifier=True)

--- a/ufl/typing.py
+++ b/ufl/typing.py
@@ -1,0 +1,10 @@
+"""Typing."""
+
+__all__ = ["Self"]
+
+# TODO: Remove this when Python 3.11 is the minimum version
+try:
+    from typing import Self
+except ImportError:
+    from typing import Any as Self
+

--- a/ufl/typing.py
+++ b/ufl/typing.py
@@ -7,4 +7,3 @@ try:
     from typing import Self
 except ImportError:
     from typing import Any as Self
-

--- a/ufl/variable.py
+++ b/ufl/variable.py
@@ -8,6 +8,7 @@ These are used to label expressions as variables for differentiation.
 # This file is part of UFL (https://www.fenicsproject.org)
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
+import functools
 import typing
 
 from ufl.constantvalue import as_ufl
@@ -68,6 +69,7 @@ class Label(Terminal, Counted):
             return ("Label", self._count)
         return ("Label", renumbering[self])
 
+    @functools.lru_cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 
@@ -138,6 +140,7 @@ class Variable(Operator):
         """Format as a string."""
         return "var%d(%s)" % (self.ufl_operands[1].count(), self.ufl_operands[0])
 
+    @functools.lru_cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 

--- a/ufl/variable.py
+++ b/ufl/variable.py
@@ -2,19 +2,21 @@
 
 These are used to label expressions as variables for differentiation.
 """
+
 # Copyright (C) 2008-2016 Martin Sandve Alnæs
 #
 # This file is part of UFL (https://www.fenicsproject.org)
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
+import typing
 
 from ufl.constantvalue import as_ufl
 from ufl.core.expr import Expr
 from ufl.core.operator import Operator
 from ufl.core.terminal import Terminal
 from ufl.core.ufl_type import ufl_type
-from ufl.utils.counted import Counted
 from ufl.typing import Self
+from ufl.utils.counted import Counted
 
 
 @ufl_type()
@@ -65,6 +67,13 @@ class Label(Terminal, Counted):
         if self not in renumbering:
             return ("Label", self._count)
         return ("Label", renumbering[self])
+
+    def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
+        """Apply restrictions.
+
+        Propagates restrictions in a form towards the terminals.
+        """
+        return self
 
 
 @ufl_type(is_shaping=True, is_index_free=True, num_ops=1, inherit_shape_from_operand=0)
@@ -129,9 +138,9 @@ class Variable(Operator):
         """Format as a string."""
         return "var%d(%s)" % (self.ufl_operands[1].count(), self.ufl_operands[0])
 
-    def apply_restrictions(self, side: typing.Optional[Str] = None) -> Self:
+    def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 
         Propagates restrictions in a form towards the terminals.
         """
-        return op  # TODO
+        return self.ufl_operands[0].apply_restrictions(side)

--- a/ufl/variable.py
+++ b/ufl/variable.py
@@ -8,10 +8,10 @@ These are used to label expressions as variables for differentiation.
 # This file is part of UFL (https://www.fenicsproject.org)
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
-import functools
 import typing
 
 from ufl.constantvalue import as_ufl
+from ufl.core.caching import cache
 from ufl.core.expr import Expr
 from ufl.core.operator import Operator
 from ufl.core.terminal import Terminal
@@ -69,7 +69,7 @@ class Label(Terminal, Counted):
             return ("Label", self._count)
         return ("Label", renumbering[self])
 
-    @functools.lru_cache
+    @cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 
@@ -140,7 +140,7 @@ class Variable(Operator):
         """Format as a string."""
         return "var%d(%s)" % (self.ufl_operands[1].count(), self.ufl_operands[0])
 
-    @functools.lru_cache
+    @cache
     def apply_restrictions(self, side: typing.Optional[str] = None) -> Self:
         """Apply restrictions.
 

--- a/ufl/variable.py
+++ b/ufl/variable.py
@@ -14,6 +14,7 @@ from ufl.core.operator import Operator
 from ufl.core.terminal import Terminal
 from ufl.core.ufl_type import ufl_type
 from ufl.utils.counted import Counted
+from ufl.typing import Self
 
 
 @ufl_type()
@@ -127,3 +128,10 @@ class Variable(Operator):
     def __str__(self):
         """Format as a string."""
         return "var%d(%s)" % (self.ufl_operands[1].count(), self.ufl_operands[0])
+
+    def apply_restrictions(self, side: typing.Optional[Str] = None) -> Self:
+        """Apply restrictions.
+
+        Propagates restrictions in a form towards the terminals.
+        """
+        return op  # TODO


### PR DESCRIPTION
Replace multifunction for apply_restrictions with a class method (defined in a protocol). Caching of results is now achieved using `functools.lru_cache` rather than inside the multifunction.

This will allow `apply_restrictions` to be implemented for types defined outside UFL without having to add the implementation of this to `algorithms/apply_restrictions.py`.

As far as users are concerned, there should be no noticable change.

I propose that we aim to make this change for all multifunctions (https://github.com/FEniCS/ufl/issues/273).