### PR TITLE
Remove broken/unused function

### DIFF
--- a/ufl/form.py
+++ b/ufl/form.py
@@ -371,12 +371,6 @@ class Form(BaseForm):
             self._analyze_subdomain_data()
         return self._subdomain_data
 
-    def max_subdomain_ids(self):
-        """Returns a mapping on the form ``{domain:{integral_type:max_subdomain_id}}``."""
-        if self._max_subdomain_ids is None:
-            self._analyze_subdomain_data()
-        return self._max_subdomain_ids
-
     def coefficients(self):
         """Return all ``Coefficient`` objects found in form."""
         if self._coefficients is None:


### PR DESCRIPTION
`_max_subdomain_ids` is never set in form, thus causes an error at access. It is also not computed in `_analyze_subdomain_data`.