### PR TITLE
Fix argument-formatter.

### DIFF
--- a/test/test_check_arities.py
+++ b/test/test_check_arities.py
@@ -69,6 +69,7 @@ def test_complex_arities():
     with pytest.raises(ArityMismatch):
         compute_form_data(inner(conj(v), u) * dx, complex_mode=True)
 
+
 def test_product_arity():
     cell = tetrahedron
     D = Mesh(FiniteElement("Lagrange", cell, 1, (3,), identity_pullback, H1))
@@ -81,6 +82,5 @@ def test_product_arity():
         compute_form_data(F, complex_mode=True)
 
     with pytest.raises(ArityMismatch):
-        L = inner(v,v)*dx
+        L = inner(v, v) * dx
         compute_form_data(L, complex_mode=False)
-    

--- a/test/test_check_arities.py
+++ b/test/test_check_arities.py
@@ -68,3 +68,19 @@ def test_complex_arities():
 
     with pytest.raises(ArityMismatch):
         compute_form_data(inner(conj(v), u) * dx, complex_mode=True)
+
+def test_product_arity():
+    cell = tetrahedron
+    D = Mesh(FiniteElement("Lagrange", cell, 1, (3,), identity_pullback, H1))
+    V = FunctionSpace(D, FiniteElement("Lagrange", cell, 2, (3,), identity_pullback, H1))
+    v = TestFunction(V)
+    u = TrialFunction(V)
+
+    with pytest.raises(ArityMismatch):
+        F = inner(u, u) * dx
+        compute_form_data(F, complex_mode=True)
+
+    with pytest.raises(ArityMismatch):
+        L = inner(v,v)*dx
+        compute_form_data(L, complex_mode=False)
+    

--- a/ufl/algorithms/check_arities.py
+++ b/ufl/algorithms/check_arities.py
@@ -17,7 +17,6 @@ class ArityMismatch(BaseException):
 
 def _afmt(atuple: Tuple[Argument, bool]) -> str:
     """Return a string representation of an arity tuple."""
-    raise RuntimeError("We got here with arg", atuple)
     return tuple(f"conj({arg})" if conj else str(arg) for arg, conj in atuple)
 
 

--- a/ufl/algorithms/check_arities.py
+++ b/ufl/algorithms/check_arities.py
@@ -17,7 +17,8 @@ class ArityMismatch(BaseException):
 
 def _afmt(atuple: Tuple[Argument, bool]) -> str:
     """Return a string representation of an arity tuple."""
-    return tuple(f"conj({arg})" if conj else str(arg) for arg, conj in atuple)
+    arg, conj = atuple
+    return f"conj({arg})" if conj else str(arg)
 
 
 class ArityChecker(MultiFunction):

--- a/ufl/algorithms/check_arities.py
+++ b/ufl/algorithms/check_arities.py
@@ -1,6 +1,7 @@
 """Check arities."""
 
 from itertools import chain
+from typing import Tuple
 
 from ufl.classes import Argument, Zero
 from ufl.corealg.map_dag import map_expr_dag
@@ -14,8 +15,9 @@ class ArityMismatch(BaseException):
     pass
 
 
-def _afmt(atuple):
+def _afmt(atuple: Tuple[Argument, bool]) -> str:
     """Return a string representation of an arity tuple."""
+    raise RuntimeError("We got here with arg", atuple)
     return tuple(f"conj({arg})" if conj else str(arg) for arg, conj in atuple)
 
 


### PR DESCRIPTION
Input to `_afmt` is a tuple of an argument and if it is complex.
This cannot be unpacked with a for-loop. 
New test throws the following error on main:
```bash

test_check_arities.py::test_product_arity FAILED

============================================================================= FAILURES =============================================================================
________________________________________________________________________ test_product_arity ________________________________________________________________________

    def test_product_arity():
        cell = tetrahedron
        D = Mesh(FiniteElement("Lagrange", cell, 1, (3,), identity_pullback, H1))
        V = FunctionSpace(D, FiniteElement("Lagrange", cell, 2, (3,), identity_pullback, H1))
        v = TestFunction(V)
        u = TrialFunction(V)
    
        with pytest.raises(ArityMismatch):
            F = inner(u, u) * dx
>           compute_form_data(F, complex_mode=True)

test_check_arities.py:81: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../ufl/algorithms/compute_form_data.py:427: in compute_form_data
    check_form_arity(preprocessed_form, self.original_form.arguments(), complex_mode)
../ufl/algorithms/check_arities.py:211: in check_form_arity
    check_integrand_arity(itg.integrand(), arguments, complex_mode)
../ufl/algorithms/check_arities.py:192: in check_integrand_arity
    arg_tuples = map_expr_dag(rules, expr, compress=False)
../ufl/corealg/map_dag.py:35: in map_expr_dag
    (result,) = map_expr_dags(
../ufl/corealg/map_dag.py:103: in map_expr_dags
    r = handlers[v._ufl_typecode_](v, *[vcache[u] for u in v.ufl_operands])
../ufl/algorithms/check_arities.py:78: in product
    f"{x[0].number()}, argument is {_afmt(x)}."
../ufl/algorithms/check_arities.py:19: in _afmt
    return tuple(f"conj({arg})" if conj else str(arg) for arg, conj in atuple)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

.0 = <tuple_iterator object at 0x7b0b59ffaef0>

>   return tuple(f"conj({arg})" if conj else str(arg) for arg, conj in atuple)
E   ValueError: too many values to unpack (expected 2)

../ufl/algorithms/check_arities.py:19: ValueError
```
