### PR TITLE
Use subdegree instead of superdegree to check cell bendy-ness

### DIFF
--- a/ufl/algorithms/apply_geometry_lowering.py
+++ b/ufl/algorithms/apply_geometry_lowering.py
@@ -304,7 +304,7 @@ class GeometryLoweringApplier(MultiFunction):
 
         domain = extract_unique_domain(o)
 
-        if domain.ufl_coordinate_element().embedded_superdegree > 1:
+        if domain.ufl_coordinate_element().embedded_subdegree > 1:
             # Don't lower bendy cells, instead leave it to form compiler
             warnings.warn("Only know how to compute cell edge lengths of P1 or Q1 cell.")
             return o
@@ -329,7 +329,7 @@ class GeometryLoweringApplier(MultiFunction):
 
         domain = extract_unique_domain(o)
 
-        if domain.ufl_coordinate_element().embedded_superdegree > 1:
+        if domain.ufl_coordinate_element().embedded_subdegree > 1:
             # Don't lower bendy cells, instead leave it to form compiler
             warnings.warn("Only know how to compute cell diameter of P1 or Q1 cell.")
             return o
@@ -366,7 +366,7 @@ class GeometryLoweringApplier(MultiFunction):
         if domain.ufl_cell().topological_dimension() < 3:
             raise ValueError("Facet edge lengths only make sense for topological dimension >= 3.")
 
-        elif domain.ufl_coordinate_element().embedded_superdegree > 1:
+        elif domain.ufl_coordinate_element().embedded_subdegree > 1:
             # Don't lower bendy cells, instead leave it to form compiler
             warnings.warn("Only know how to compute facet edge lengths of P1 or Q1 cell.")
             return o


### PR DESCRIPTION
Fixes https://github.com/firedrakeproject/firedrake/issues/3612

To quote @dham:

> The reason subdegree is right is that you care about whether the edges are straight, not whether there are any quadratic functions on the interior.