### PR TITLE
Make cofunctionals terminal, and test

### DIFF
--- a/test/test_equals.py
+++ b/test/test_equals.py
@@ -4,6 +4,7 @@ from ufl import Coefficient, Cofunction, FunctionSpace, Mesh, triangle
 from ufl.finiteelement import FiniteElement
 from ufl.pullback import identity_pullback
 from ufl.sobolevspace import H1
+from ufl.exprcontainers import ExprList
 
 
 def test_comparison_of_coefficients():
@@ -68,6 +69,10 @@ def test_comparison_of_cofunctions():
     assert not u1 == u2
     assert not v1 == u1
     assert not v2 == u2
+
+    # Objects in ExprList as happens when taking derivatives.
+    assert ExprList(v1, v1) == ExprList(v1, v1b)
+    assert not ExprList(v1, v2) == ExprList(v1, v1)
 
 
 def test_comparison_of_products():

--- a/ufl/coefficient.py
+++ b/ufl/coefficient.py
@@ -118,6 +118,7 @@ class Cofunction(BaseCoefficient, BaseForm):
     )
     _primal = False
     _dual = True
+    _ufl_is_terminal_ = True
 
     __eq__ = BaseForm.__eq__
 

--- a/ufl/formatting/ufl2unicode.py
+++ b/ufl/formatting/ufl2unicode.py
@@ -485,9 +485,25 @@ class Expression2UnicodeHandler(MultiFunction):
             return f"{var}{subscript_number(i)}"
         return self.coefficient_names[o.count()]
 
+    def cofunction(self, o):
+        """Format a cofunction."""
+        if self.coefficient_names is None:
+            i = o.count()
+            var = "cofunction"
+            if len(o.ufl_shape) == 1:
+                var += UC.combining_right_arrow_above
+            elif len(o.ufl_shape) > 1 and self.colorama_bold:
+                var = f"{colorama.Style.BRIGHT}{var}{colorama.Style.RESET_ALL}"
+            return f"{var}{subscript_number(i)}"
+        return self.coefficient_names[o.count()]
+
     def base_form_operator(self, o):
         """Format a base_form_operator."""
         return "BaseFormOperator"
+
+    def action(self, o, a, b):
+        """Format an Action."""
+        return f"Action({a}, {b})"
 
     def constant(self, o):
         """Format a constant."""


### PR DESCRIPTION
When taking derivatives with respect to a `Cofunction`, ufl ends up creating `ExprList` objects containing cofunctions. Equality (`==`) then fails on the `ExprList` because the `Cofunction` is not identified as a terminal. This fixes that and puts in a test.

Also adds unicode methods for a couple of missing things that were hit along the way. The whole unicode conversion is untested and I'm not proposing to fix that here.