### PR TITLE
Move grouping of integral from `build_integral_data` to `group_form_integrals`

### DIFF
--- a/test/test_indices.py
+++ b/test/test_indices.py
@@ -1,5 +1,7 @@
 import pytest
 
+import ufl.algorithms
+import ufl.classes
 from ufl import (
     Argument,
     Coefficient,
@@ -23,9 +25,6 @@ from ufl import (
     sin,
     triangle,
 )
-import ufl.algorithms
-import ufl.classes
-from ufl import indices
 from ufl.classes import IndexSum
 from ufl.finiteelement import FiniteElement
 from ufl.pullback import identity_pullback
@@ -309,22 +308,33 @@ def test_spatial_derivative(self):
 
 
 def test_renumbering(self):
-    """Test that kernels with common integral data, but different index numbering, are correctly renumbered."""
+    """Test that kernels with common integral data, but different index numbering,
+    are correctly renumbered."""
     cell = interval
-    mesh = Mesh(FiniteElement("Lagrange", cell, 1, (2, ), identity_pullback, H1))
-    V = FunctionSpace(mesh, FiniteElement("Lagrange", cell, 1, (2, ), identity_pullback, H1))
+    mesh = Mesh(FiniteElement("Lagrange", cell, 1, (2,), identity_pullback, H1))
+    V = FunctionSpace(mesh, FiniteElement("Lagrange", cell, 1, (2,), identity_pullback, H1))
     v = TestFunction(V)
     u = TrialFunction(V)
     i = indices(1)
-    a0 = u[i].dx(0)*v[i].dx(0) * ufl.dx((1))
-    a1 = u[i].dx(0)*v[i].dx(0) * ufl.dx((2,3,))
+    a0 = u[i].dx(0) * v[i].dx(0) * ufl.dx((1))
+    a1 = (
+        u[i].dx(0)
+        * v[i].dx(0)
+        * ufl.dx(
+            (
+                2,
+                3,
+            )
+        )
+    )
     form_data = ufl.algorithms.compute_form_data(
-    a0+a1,
-    do_apply_function_pullbacks=True,
-    do_apply_integral_scaling=True,
-    do_apply_geometry_lowering=True,
-    preserve_geometry_types=(ufl.classes.Jacobian,),
-    do_apply_restrictions=True,
-    do_append_everywhere_integrals=False)
-    
+        a0 + a1,
+        do_apply_function_pullbacks=True,
+        do_apply_integral_scaling=True,
+        do_apply_geometry_lowering=True,
+        preserve_geometry_types=(ufl.classes.Jacobian,),
+        do_apply_restrictions=True,
+        do_append_everywhere_integrals=False,
+    )
+
     assert len(form_data.integral_data) == 1

--- a/ufl/algorithms/domain_analysis.py
+++ b/ufl/algorithms/domain_analysis.py
@@ -15,6 +15,7 @@ from ufl.algorithms.coordinate_derivative_helpers import (
     attach_coordinate_derivatives,
     strip_coordinate_derivatives,
 )
+from ufl.algorithms.renumbering import renumber_indices
 from ufl.form import Form
 from ufl.integral import Integral
 from ufl.protocols import id_or_none
@@ -372,7 +373,7 @@ def group_form_integrals(form, domains, do_append_everywhere_integrals=True):
         meta_hash = hash(canonicalize_metadata(metadata))
         subdomain_id = integral.subdomain_id()
         subdomain_data = id_or_none(integral.subdomain_data())
-        integrand = integral.integrand()
+        integrand = renumber_indices(integral.integrand())
         unique_integrals[(integral_type, ufl_domain, meta_hash, integrand, subdomain_data)] += (
             subdomain_id,
         )

--- a/ufl/algorithms/domain_analysis.py
+++ b/ufl/algorithms/domain_analysis.py
@@ -262,37 +262,17 @@ def build_integral_data(integrals):
     itgs = defaultdict(list)
 
     # --- Merge integral data that has the same integrals,
-    unique_integrals = defaultdict(tuple)
-    metadata_table = defaultdict(dict)
     for integral in integrals:
-        integrand = integral.integrand()
         integral_type = integral.integral_type()
         ufl_domain = integral.ufl_domain()
-        metadata = integral.metadata()
-        meta_hash = hash(canonicalize_metadata(metadata))
-        subdomain_id = integral.subdomain_id()
-        subdomain_data = id_or_none(integral.subdomain_data())
-        if subdomain_id == "everywhere":
+        subdomain_ids = integral.subdomain_id()
+        if "everywhere" in subdomain_ids:
+ 
             raise ValueError(
                 "'everywhere' not a valid subdomain id. "
                 "Did you forget to call group_form_integrals?"
             )
-        unique_integrals[(integral_type, ufl_domain, meta_hash, integrand, subdomain_data)] += (
-            subdomain_id,
-        )
-        metadata_table[(integral_type, ufl_domain, meta_hash, integrand, subdomain_data)] = metadata
-
-    for integral_data, subdomain_ids in unique_integrals.items():
-        (integral_type, ufl_domain, metadata, integrand, subdomain_data) = integral_data
-
-        integral = Integral(
-            integrand,
-            integral_type,
-            ufl_domain,
-            subdomain_ids,
-            metadata_table[integral_data],
-            subdomain_data,
-        )
+        
         # Group for integral data (One integral data object for all
         # integrals with same domain, itype, (but possibly different metadata).
         itgs[(ufl_domain, integral_type, subdomain_ids)].append(integral)
@@ -380,7 +360,30 @@ def group_form_integrals(form, domains, do_append_everywhere_integrals=True):
                         )
                         integral = attach_coordinate_derivatives(integral, samecd_integrals[0])
                         integrals.append(integral)
-    return Form(integrals)
+
+    # Group integrals by common subdomain id
+    # u.dx(0)*dx(1) + u.dx(0)*dx(2) -> u.dx(0)*dx((1,2))
+    # to avoid duplicate kernels generated after geoemtry lowering
+    unique_integrals = defaultdict(tuple)
+    metadata_table = defaultdict(dict)
+    for integral in integrals:
+        integral_type = integral.integral_type()
+        ufl_domain = integral.ufl_domain()
+        metadata = integral.metadata()
+        meta_hash = hash(canonicalize_metadata(metadata))
+        subdomain_id = integral.subdomain_id()
+        subdomain_data = id_or_none(integral.subdomain_data())
+        unique_integrals[(integral_type, ufl_domain, meta_hash, integrand, subdomain_data)] += (subdomain_id,)
+        metadata_table[(integral_type, ufl_domain, meta_hash, integrand, subdomain_data)] = metadata
+    
+    grouped_integrals = []
+    for integral_data, subdomain_ids in unique_integrals.items():
+        (integral_type, ufl_domain, metadata, integrand, subdomain_data) = integral_data
+        integral = Integral(integrand, integral_type, ufl_domain, subdomain_ids,
+                            metadata_table[integral_data], subdomain_data)
+        grouped_integrals.append(integral)
+
+    return Form(grouped_integrals)
 
 
 def reconstruct_form_from_integral_data(integral_data):

--- a/ufl/algorithms/domain_analysis.py
+++ b/ufl/algorithms/domain_analysis.py
@@ -372,6 +372,7 @@ def group_form_integrals(form, domains, do_append_everywhere_integrals=True):
         meta_hash = hash(canonicalize_metadata(metadata))
         subdomain_id = integral.subdomain_id()
         subdomain_data = id_or_none(integral.subdomain_data())
+        integrand = integral.integrand()
         unique_integrals[(integral_type, ufl_domain, meta_hash, integrand, subdomain_data)] += (
             subdomain_id,
         )

--- a/ufl/algorithms/domain_analysis.py
+++ b/ufl/algorithms/domain_analysis.py
@@ -363,7 +363,7 @@ def group_form_integrals(form, domains, do_append_everywhere_integrals=True):
 
     # Group integrals by common subdomain id
     # u.dx(0)*dx(1) + u.dx(0)*dx(2) -> u.dx(0)*dx((1,2))
-    # to avoid duplicate kernels generated after geoemtry lowering
+    # to avoid duplicate kernels generated after geometry lowering
     unique_integrals = defaultdict(tuple)
     metadata_table = defaultdict(dict)
     for integral in integrals:

--- a/ufl/algorithms/domain_analysis.py
+++ b/ufl/algorithms/domain_analysis.py
@@ -361,7 +361,7 @@ def group_form_integrals(form, domains, do_append_everywhere_integrals=True):
                         integral = attach_coordinate_derivatives(integral, samecd_integrals[0])
                         integrals.append(integral)
 
-    # Group integrals by common subdomain id
+    # Group integrals by common integrand
     # u.dx(0)*dx(1) + u.dx(0)*dx(2) -> u.dx(0)*dx((1,2))
     # to avoid duplicate kernels generated after geometry lowering
     unique_integrals = defaultdict(tuple)

--- a/ufl/algorithms/domain_analysis.py
+++ b/ufl/algorithms/domain_analysis.py
@@ -267,12 +267,11 @@ def build_integral_data(integrals):
         ufl_domain = integral.ufl_domain()
         subdomain_ids = integral.subdomain_id()
         if "everywhere" in subdomain_ids:
- 
             raise ValueError(
                 "'everywhere' not a valid subdomain id. "
                 "Did you forget to call group_form_integrals?"
             )
-        
+
         # Group for integral data (One integral data object for all
         # integrals with same domain, itype, (but possibly different metadata).
         itgs[(ufl_domain, integral_type, subdomain_ids)].append(integral)
@@ -373,14 +372,22 @@ def group_form_integrals(form, domains, do_append_everywhere_integrals=True):
         meta_hash = hash(canonicalize_metadata(metadata))
         subdomain_id = integral.subdomain_id()
         subdomain_data = id_or_none(integral.subdomain_data())
-        unique_integrals[(integral_type, ufl_domain, meta_hash, integrand, subdomain_data)] += (subdomain_id,)
+        unique_integrals[(integral_type, ufl_domain, meta_hash, integrand, subdomain_data)] += (
+            subdomain_id,
+        )
         metadata_table[(integral_type, ufl_domain, meta_hash, integrand, subdomain_data)] = metadata
-    
+
     grouped_integrals = []
     for integral_data, subdomain_ids in unique_integrals.items():
         (integral_type, ufl_domain, metadata, integrand, subdomain_data) = integral_data
-        integral = Integral(integrand, integral_type, ufl_domain, subdomain_ids,
-                            metadata_table[integral_data], subdomain_data)
+        integral = Integral(
+            integrand,
+            integral_type,
+            ufl_domain,
+            subdomain_ids,
+            metadata_table[integral_data],
+            subdomain_data,
+        )
         grouped_integrals.append(integral)
 
     return Form(grouped_integrals)

--- a/ufl/algorithms/renumbering.py
+++ b/ufl/algorithms/renumbering.py
@@ -8,12 +8,9 @@
 from collections import defaultdict
 from itertools import count as _count
 
-from ufl.classes import Form, Integral
-from ufl.core.expr import Expr
 from ufl.core.multiindex import Index
-from ufl.corealg.map_dag import map_expr_dag
 from ufl.corealg.multifunction import MultiFunction
-
+from ufl.algorithms.map_integrands import map_integrand_dags
 
 class IndexRelabeller(MultiFunction):
     """Renumber indices to have a consistent index numbering starting from 0."""
@@ -55,17 +52,6 @@ def renumber_indices(form):
     Returns:
         A new form, integral or expression with renumbered indices.
     """
-    if isinstance(form, Form):
-        new_integrals = [renumber_indices(itg) for itg in form.integrals()]
-        return Form(new_integrals)
-    elif isinstance(form, Integral):
-        integral = form
-        reindexer = IndexRelabeller()
-        new_integrand = map_expr_dag(reindexer, integral.integrand())
-        return integral.reconstruct(new_integrand)
-    elif isinstance(form, Expr):
-        expr = form
-        reindexer = IndexRelabeller()
-        return map_expr_dag(reindexer, expr)
-    else:
-        raise ValueError(f"Invalid form type {form.__class__name}")
+
+    reindexer = IndexRelabeller()
+    return map_integrand_dags(reindexer, form)

--- a/ufl/algorithms/renumbering.py
+++ b/ufl/algorithms/renumbering.py
@@ -8,9 +8,10 @@
 from collections import defaultdict
 from itertools import count as _count
 
+from ufl.algorithms.map_integrands import map_integrand_dags
 from ufl.core.multiindex import Index
 from ufl.corealg.multifunction import MultiFunction
-from ufl.algorithms.map_integrands import map_integrand_dags
+
 
 class IndexRelabeller(MultiFunction):
     """Renumber indices to have a consistent index numbering starting from 0."""
@@ -52,6 +53,5 @@ def renumber_indices(form):
     Returns:
         A new form, integral or expression with renumbered indices.
     """
-
     reindexer = IndexRelabeller()
     return map_integrand_dags(reindexer, form)

--- a/ufl/algorithms/renumbering.py
+++ b/ufl/algorithms/renumbering.py
@@ -48,7 +48,7 @@ class IndexRenumberingTransformer(VariableRenumberingTransformer):
         """Apply to zero."""
         fi = o.ufl_free_indices
         fid = o.ufl_index_dimensions
-        if fi == () and fid ==():
+        if fi == () and fid == ():
             return o
         mapped_fi = tuple(self.index(Index(count=i)) for i in fi)
         paired_fid = [(mapped_fi[pos], fid[pos]) for pos, a in enumerate(fi)]

--- a/ufl/algorithms/renumbering.py
+++ b/ufl/algorithms/renumbering.py
@@ -48,6 +48,8 @@ class IndexRenumberingTransformer(VariableRenumberingTransformer):
         """Apply to zero."""
         fi = o.ufl_free_indices
         fid = o.ufl_index_dimensions
+        if fi == () and fid ==():
+            return o
         mapped_fi = tuple(self.index(Index(count=i)) for i in fi)
         paired_fid = [(mapped_fi[pos], fid[pos]) for pos, a in enumerate(fi)]
         new_fi, new_fid = zip(*tuple(sorted(paired_fid)))

--- a/ufl/algorithms/renumbering.py
+++ b/ufl/algorithms/renumbering.py
@@ -1,5 +1,5 @@
 """Algorithms for renumbering of counted objects, currently variables and indices."""
-# Copyright (C) 2008-2024 Martin Sandve Alnæs, Anders Logg, Jø¶gen S. Dokken and Lawerence Mitchell
+# Copyright (C) 2008-2024 Martin Sandve Alnæs, Anders Logg, Jørgen S. Dokken and Lawerence Mitchell
 #
 # This file is part of UFL (https://www.fenicsproject.org)
 #

--- a/ufl/algorithms/renumbering.py
+++ b/ufl/algorithms/renumbering.py
@@ -1,5 +1,5 @@
 """Algorithms for renumbering of counted objects, currently variables and indices."""
-# Copyright (C) 2008-2024 Martin Sandve Alnæs, Anders Logg, Jørgen S. Dokken and Lawerence Mitchell
+# Copyright (C) 2008-2024 Martin Sandve Alnæs, Anders Logg, Jørgen S. Dokken and Lawrence Mitchell
 #
 # This file is part of UFL (https://www.fenicsproject.org)
 #


### PR DESCRIPTION
Move group to resolve #304 by grouping prior to pull-back.
This will resolve https://github.com/FEniCS/ffcx/issues/716 as well.

I think this is a better fix than what I came up with in https://github.com/FEniCS/ufl/pull/92/files
as we now group the integrals in the function that is supposed to do grouping, and it will reduce the load of the other functions (pull-back, geometry_lowering etc.) since it happens at the start of `compute_form_data`.