### PR TITLE
Extend `FormSplitter` to handle restrictions

### DIFF
--- a/test/test_extract_blocks.py
+++ b/test/test_extract_blocks.py
@@ -4,6 +4,7 @@ import ufl
 import ufl.algorithms
 from ufl.finiteelement import FiniteElement, MixedElement
 
+
 def epsilon(u):
     return ufl.sym(ufl.grad(u))
 
@@ -80,19 +81,23 @@ def test_extract_blocks(rank):
                 J_ij_ext = ufl.extract_blocks(J, i, j)
                 assert J_sub[2 * i + j].signature() == J_ij_ext.signature()
 
+
 def test_postive_restricted_extract_none():
     cell = ufl.triangle
     d = cell.topological_dimension()
     domain = ufl.Mesh(FiniteElement("Lagrange", cell, 1, (d,), ufl.identity_pullback, ufl.H1))
-    el_u = FiniteElement("Lagrange", cell, 2, (d, ), ufl.identity_pullback, ufl.H1)
-    el_p = FiniteElement(
-        "Lagrange", cell, 1, (), ufl.identity_pullback, ufl.H1)
+    el_u = FiniteElement("Lagrange", cell, 2, (d,), ufl.identity_pullback, ufl.H1)
+    el_p = FiniteElement("Lagrange", cell, 1, (), ufl.identity_pullback, ufl.H1)
     V = ufl.FunctionSpace(domain, el_u)
     Q = ufl.FunctionSpace(domain, el_p)
     W = ufl.MixedFunctionSpace(V, Q)
     u, p = ufl.TrialFunctions(W)
-    v, q = ufl.TestFunctions(W) 
-    a = ufl.inner(ufl.grad(u), ufl.grad(v))*ufl.dx + ufl.div(u)*q*ufl.dx + ufl.div(v)*p*ufl.dx
-    a += ufl.inner(u("+"),v("+")) * ufl.dS
+    v, q = ufl.TestFunctions(W)
+    a = (
+        ufl.inner(ufl.grad(u), ufl.grad(v)) * ufl.dx
+        + ufl.div(u) * q * ufl.dx
+        + ufl.div(v) * p * ufl.dx
+    )
+    a += ufl.inner(u("+"), v("+")) * ufl.dS
     a_blocks = ufl.extract_blocks(a)
     assert a_blocks[1][1] is None

--- a/test/test_extract_blocks.py
+++ b/test/test_extract_blocks.py
@@ -4,7 +4,6 @@ import ufl
 import ufl.algorithms
 from ufl.finiteelement import FiniteElement, MixedElement
 
-
 def epsilon(u):
     return ufl.sym(ufl.grad(u))
 
@@ -80,3 +79,20 @@ def test_extract_blocks(rank):
             for j in range(2):
                 J_ij_ext = ufl.extract_blocks(J, i, j)
                 assert J_sub[2 * i + j].signature() == J_ij_ext.signature()
+
+def test_postive_restricted_extract_none():
+    cell = ufl.triangle
+    d = cell.topological_dimension()
+    domain = ufl.Mesh(FiniteElement("Lagrange", cell, 1, (d,), ufl.identity_pullback, ufl.H1))
+    el_u = FiniteElement("Lagrange", cell, 2, (d, ), ufl.identity_pullback, ufl.H1)
+    el_p = FiniteElement(
+        "Lagrange", cell, 1, (), ufl.identity_pullback, ufl.H1)
+    V = ufl.FunctionSpace(domain, el_u)
+    Q = ufl.FunctionSpace(domain, el_p)
+    W = ufl.MixedFunctionSpace(V, Q)
+    u, p = ufl.TrialFunctions(W)
+    v, q = ufl.TestFunctions(W) 
+    a = ufl.inner(ufl.grad(u), ufl.grad(v))*ufl.dx + ufl.div(u)*q*ufl.dx + ufl.div(v)*p*ufl.dx
+    a += ufl.inner(u("+"),v("+")) * ufl.dS
+    a_blocks = ufl.extract_blocks(a)
+    assert a_blocks[1][1] is None

--- a/ufl/algorithms/formsplitter.py
+++ b/ufl/algorithms/formsplitter.py
@@ -82,7 +82,7 @@ class FormSplitter(MultiFunction):
         return obj
 
     def restricted(self, o):
-        """Apply to a restricted function"""
+        """Apply to a restricted function."""
         # If we hit a restriction first apply form splitter to argument, then check for zero
         op_split = map_expr_dag(self, o.ufl_operands[0])
         if isinstance(op_split, Zero):

--- a/ufl/algorithms/formsplitter.py
+++ b/ufl/algorithms/formsplitter.py
@@ -10,6 +10,7 @@
 
 from typing import Optional
 
+from ufl.algorithms.apply_restrictions import apply_restrictions
 from ufl.algorithms.map_integrands import map_integrand_dags
 from ufl.argument import Argument
 from ufl.classes import FixedIndex, ListTensor
@@ -139,7 +140,14 @@ def extract_blocks(form, i: Optional[int] = None, j: Optional[None] = None):
                 if f.empty():
                     form_i.append(None)
                 elif f.arguments() == ():
-                    form_i.append(None)
+                    # Restrict interior facet integrals to eliminate zeros
+                    f = apply_restrictions(f)
+                    if f.empty():
+                        form_i.append(None)
+                    else:
+                        raise RuntimeError(
+                            "Extracted form with no arguments that does not reduce to 0."
+                        )
                 else:
                     form_i.append(f)
             forms.append(tuple(form_i))

--- a/ufl/algorithms/formsplitter.py
+++ b/ufl/algorithms/formsplitter.py
@@ -138,6 +138,8 @@ def extract_blocks(form, i: Optional[int] = None, j: Optional[None] = None):
                 f = fs.split(form, pi, pj)
                 if f.empty():
                     form_i.append(None)
+                elif f.arguments() == ():
+                    form_i.append(None)
                 else:
                     form_i.append(f)
             forms.append(tuple(form_i))


### PR DESCRIPTION
When extracting blocks, one can end up with `PositiveRestriction(Zero())` in the form when using `dS` integrals, and extracting a block with no contribution.
MWE:
```python
   domain = ufl.Mesh(FiniteElement("Lagrange", cell, 1, (d,), ufl.identity_pullback, ufl.H1))
    el_u = FiniteElement("Lagrange", cell, 2, (d, ), ufl.identity_pullback, ufl.H1)
    el_p = FiniteElement(
        "Lagrange", cell, 1, (), ufl.identity_pullback, ufl.H1)
    V = ufl.FunctionSpace(domain, el_u)
    Q = ufl.FunctionSpace(domain, el_p)
    W = ufl.MixedFunctionSpace(V, Q)
    u, p = ufl.TrialFunctions(W)
    v, q = ufl.TestFunctions(W) 
    a = ufl.inner(ufl.grad(u), ufl.grad(v))*ufl.dx + ufl.div(u)*q*ufl.dx + ufl.div(v)*p*ufl.dx
    a += ufl.inner(u("+"),v("+")) * ufl.dS
    a_blocks = ufl.extract_blocks(a)
    assert a_blocks[1][1] is None
```
does not return a zero form.

This PR extends `FormSplitter` such that 
`split(Restriction(expr))`
now returns
`Zero` if `split(expr)=Zero` 