### PR TITLE
Fix `is_cellwise_constant(ReferenceGrad(x))`

### DIFF
--- a/test/test_change_to_local.py
+++ b/test/test_change_to_local.py
@@ -12,8 +12,8 @@ from ufl.sobolevspace import H1
 def test_change_to_reference_grad():
     cell = triangle
     domain = Mesh(FiniteElement("Lagrange", cell, 1, (2,), identity_pullback, H1))
-    U = FunctionSpace(domain, FiniteElement("Lagrange", cell, 1, (), identity_pullback, H1))
-    V = FunctionSpace(domain, FiniteElement("Lagrange", cell, 1, (2,), identity_pullback, H1))
+    U = FunctionSpace(domain, FiniteElement("Lagrange", cell, 3, (), identity_pullback, H1))
+    V = FunctionSpace(domain, FiniteElement("Lagrange", cell, 3, (2,), identity_pullback, H1))
     u = Coefficient(U)
     v = Coefficient(V)
     Jinv = JacobianInverse(domain)


### PR DESCRIPTION
Adding a special case to detect that the reference gradient of a P1 field is cellwise constant.