### PR TITLE
Simplify indexed ListTensor objects

### DIFF
--- a/test/test_simplify.py
+++ b/test/test_simplify.py
@@ -1,5 +1,8 @@
 import math
 
+import pytest
+from numpy import ndindex, reshape
+
 from ufl import (
     Coefficient,
     FunctionSpace,
@@ -162,3 +165,12 @@ def test_indexing(self):
     Bij2 = as_tensor(Bij, (i, j))[i, j]
     as_tensor(Bij, (i, j))
     assert Bij2 == Bij
+
+
+@pytest.mark.parametrize("shape", [(3,), (3, 2)], ids=("vector", "matrix"))
+def test_tensor_from_indexed(self, shape):
+    element = FiniteElement("Lagrange", triangle, 1, shape, identity_pullback, H1)
+    domain = Mesh(FiniteElement("Lagrange", triangle, 1, (2,), identity_pullback, H1))
+    space = FunctionSpace(domain, element)
+    f = Coefficient(space)
+    assert as_tensor(reshape([f[i] for i in ndindex(f.ufl_shape)], f.ufl_shape).tolist()) is f

--- a/test/test_simplify.py
+++ b/test/test_simplify.py
@@ -32,7 +32,9 @@ from ufl import (
     triangle,
 )
 from ufl.algorithms import compute_form_data
+from ufl.core.multiindex import FixedIndex, MultiIndex
 from ufl.finiteelement import FiniteElement
+from ufl.indexed import Indexed
 from ufl.pullback import identity_pullback
 from ufl.sobolevspace import H1
 
@@ -174,3 +176,20 @@ def test_tensor_from_indexed(self, shape):
     space = FunctionSpace(domain, element)
     f = Coefficient(space)
     assert as_tensor(reshape([f[i] for i in ndindex(f.ufl_shape)], f.ufl_shape).tolist()) is f
+
+
+def test_nested_indexed(self):
+    # Test that a nested Indexed expression simplifies to the existing Indexed object
+    shape = (2,)
+    element = FiniteElement("Lagrange", triangle, 1, shape, identity_pullback, H1)
+    domain = Mesh(FiniteElement("Lagrange", triangle, 1, (2,), identity_pullback, H1))
+    space = FunctionSpace(domain, element)
+    f = Coefficient(space)
+
+    comps = tuple(f[i] for i in range(2))
+    assert all(isinstance(c, Indexed) for c in comps)
+    expr = as_tensor(list(reversed(comps)))
+
+    multiindex = MultiIndex((FixedIndex(0),))
+    assert Indexed(expr, multiindex) is expr[0]
+    assert Indexed(expr, multiindex) is comps[1]

--- a/test/test_str.py
+++ b/test/test_str.py
@@ -97,8 +97,8 @@ def test_str_scalar_argument(self):
 def test_str_list_vector():
     domain = Mesh(FiniteElement("Lagrange", tetrahedron, 1, (3,), identity_pullback, H1))
     x, y, z = SpatialCoordinate(domain)
-    v = as_vector((x, y, z))
-    assert str(v) == ("[%s, %s, %s]" % (x, y, z))
+    v = as_vector((z, y, x))
+    assert str(v) == ("[%s, %s, %s]" % (z, y, x))
 
 
 def test_str_list_vector_with_zero():

--- a/ufl/algorithms/formsplitter.py
+++ b/ufl/algorithms/formsplitter.py
@@ -74,7 +74,7 @@ class FormSplitter(MultiFunction):
             if len(indices) == 1:
                 return child[indices[0]]
             elif len(indices) == len(child.ufl_operands) and all(
-                k == i for k, i in enumerate(indices)
+                k == int(i) for k, i in enumerate(indices)
             ):
                 return child
             else:

--- a/ufl/algorithms/formsplitter.py
+++ b/ufl/algorithms/formsplitter.py
@@ -10,6 +10,8 @@
 
 from typing import Optional
 
+import numpy as np
+
 from ufl.algorithms.map_integrands import map_expr_dag, map_integrand_dags
 from ufl.argument import Argument
 from ufl.classes import FixedIndex, ListTensor
@@ -53,14 +55,10 @@ class FormSplitter(MultiFunction):
                 Q_i = FunctionSpace(dom, sub_elem)
                 a = Argument(Q_i, obj.number(), part=obj.part())
 
-                indices = [()]
-                for m in a.ufl_shape:
-                    indices = [(*k, j) for k in indices for j in range(m)]
-
                 if i == self.idx[obj.number()]:
-                    args.extend(a[j] for j in indices)
+                    args.extend(a[j] for j in np.ndindex(a.ufl_shape))
                 else:
-                    args.extend(Zero() for j in indices)
+                    args.extend(Zero() for j in np.ndindex(a.ufl_shape))
 
             return as_vector(args)
 

--- a/ufl/algorithms/transformer.py
+++ b/ufl/algorithms/transformer.py
@@ -90,7 +90,7 @@ class Transformer(object):
             n = 160 - len(ss)
             return ss + str(s)[:n]
 
-        print("\n".join(sstr(s) for s in self._visit_stack))
+        print("\n".join(map(sstr, self._visit_stack)))
         print("\\" * 80)
 
     def visit(self, o):
@@ -106,7 +106,7 @@ class Transformer(object):
         # input?
         if visit_children_first:
             # Yes, visit all children first and then call h.
-            r = h(o, *[self.visit(op) for op in o.ufl_operands])
+            r = h(o, *map(self.visit, o.ufl_operands))
         else:
             # No, this is a handler that handles its own children
             # (arguments self and o, where self is already bound)
@@ -241,7 +241,7 @@ def apply_transformer(e, transformer, integral_type=None):
     Apply transformer.visit(expression) to each integrand expression in
     form, or to form if it is an Expr.
     """
-    return map_integrands(lambda expr: transformer.visit(expr), e, integral_type)
+    return map_integrands(transformer.visit, e, integral_type)
 
 
 def strip_variables(e):

--- a/ufl/core/multiindex.py
+++ b/ufl/core/multiindex.py
@@ -62,9 +62,7 @@ class FixedIndex(IndexBase):
 
     def __eq__(self, other):
         """Check equality."""
-        if isinstance(other, FixedIndex):
-            other = int(other)
-        return isinstance(other, int) and int(self) == other
+        return isinstance(other, (FixedIndex, int)) and int(self) == int(other)
 
     def __int__(self):
         """Convert to int."""
@@ -164,7 +162,7 @@ class MultiIndex(Terminal):
 
     def _ufl_compute_hash_(self):
         """Compute UFL hash."""
-        return hash(("MultiIndex",) + tuple(hash(ind) for ind in self._indices))
+        return hash(("MultiIndex", *map(hash, self._indices)))
 
     def __eq__(self, other):
         """Check equality."""
@@ -238,7 +236,7 @@ class MultiIndex(Terminal):
 
     def __str__(self):
         """Format as a string."""
-        return ", ".join(str(i) for i in self._indices)
+        return ", ".join(map(str, self._indices))
 
     def __repr__(self):
         """Return representation."""

--- a/ufl/core/multiindex.py
+++ b/ufl/core/multiindex.py
@@ -62,7 +62,9 @@ class FixedIndex(IndexBase):
 
     def __eq__(self, other):
         """Check equality."""
-        return isinstance(other, FixedIndex) and (self._value == other._value)
+        if isinstance(other, FixedIndex):
+            other = int(other)
+        return isinstance(other, int) and int(self) == other
 
     def __int__(self):
         """Convert to int."""

--- a/ufl/core/operator.py
+++ b/ufl/core/operator.py
@@ -39,9 +39,9 @@ class Operator(Expr):
 
     def _ufl_compute_hash_(self):
         """Compute a hash code for this expression. Used by sets and dicts."""
-        return hash((self._ufl_typecode_,) + tuple(hash(o) for o in self.ufl_operands))
+        return hash((self._ufl_typecode_,) + tuple(map(hash, self.ufl_operands)))
 
     def __repr__(self):
         """Default repr string construction for operators."""
         # This should work for most cases
-        return f"{self._ufl_class_.__name__}({', '.join(repr(op) for op in self.ufl_operands)})"
+        return f"{self._ufl_class_.__name__}({', '.join(map(repr, self.ufl_operands))})"

--- a/ufl/core/operator.py
+++ b/ufl/core/operator.py
@@ -39,7 +39,7 @@ class Operator(Expr):
 
     def _ufl_compute_hash_(self):
         """Compute a hash code for this expression. Used by sets and dicts."""
-        return hash((self._ufl_typecode_,) + tuple(map(hash, self.ufl_operands)))
+        return hash((self._ufl_typecode_, *map(hash, self.ufl_operands)))
 
     def __repr__(self):
         """Default repr string construction for operators."""

--- a/ufl/corealg/multifunction.py
+++ b/ufl/corealg/multifunction.py
@@ -7,14 +7,12 @@
 #
 # Modified by Massimiliano Leoni, 2016
 
-from functools import cache
 from inspect import signature
 
 from ufl.core.expr import Expr
 from ufl.core.ufl_type import UFLType
 
 
-@cache
 def get_num_args(function):
     """Return the number of arguments accepted by *function*."""
     sig = signature(function)

--- a/ufl/corealg/multifunction.py
+++ b/ufl/corealg/multifunction.py
@@ -7,15 +7,17 @@
 #
 # Modified by Massimiliano Leoni, 2016
 
-import inspect
+from functools import cache
+from inspect import signature
 
 from ufl.core.expr import Expr
 from ufl.core.ufl_type import UFLType
 
 
+@cache
 def get_num_args(function):
     """Return the number of arguments accepted by *function*."""
-    sig = inspect.signature(function)
+    sig = signature(function)
     return len(sig.parameters) + 1
 
 

--- a/ufl/form.py
+++ b/ufl/form.py
@@ -120,6 +120,10 @@ class BaseForm(object, metaclass=UFLType):
         # Return the one and only domain
         return domain
 
+    def empty(self):
+        """Returns whether the BaseForm has no components."""
+        return False
+
     # --- Operator implementations ---
 
     def __eq__(self, other):
@@ -307,7 +311,7 @@ class Form(BaseForm):
 
     def empty(self):
         """Returns whether the form has no integrals."""
-        return self.integrals() == ()
+        return len(self.integrals()) == 0
 
     def ufl_domains(self):
         """Return the geometric integration domains occuring in the form.
@@ -811,6 +815,10 @@ class FormSum(BaseForm):
         return len(self.components()) == len(other.components()) and all(
             a == b for a, b in zip(self.components(), other.components())
         )
+
+    def empty(self):
+        """Returns whether the FormSum has no components."""
+        return len(self.components()) == 0
 
     def __str__(self):
         """Compute shorter string representation of form. This can be huge for complicated forms."""

--- a/ufl/form.py
+++ b/ufl/form.py
@@ -563,7 +563,7 @@ class Form(BaseForm):
         # warning("Calling str on form is potentially expensive and
         # should be avoided except during debugging.") Not caching this
         # because it can be huge
-        s = "\n  +  ".join(str(itg) for itg in self.integrals())
+        s = "\n  +  ".join(map(str, self.integrals()))
         return s or "<empty Form>"
 
     def __repr__(self):
@@ -572,7 +572,7 @@ class Form(BaseForm):
         # warning("Calling repr on form is potentially expensive and
         # should be avoided except during debugging.") Not caching this
         # because it can be huge
-        itgs = ", ".join(repr(itg) for itg in self.integrals())
+        itgs = ", ".join(map(repr, self.integrals()))
         r = "Form([" + itgs + "])"
         return r
 
@@ -864,6 +864,7 @@ class ZeroBaseForm(BaseForm):
         self._arguments = arguments
         self.ufl_operands = arguments
         self._hash = None
+        self._domains = None
         self.form = None
 
     def _analyze_form_arguments(self):

--- a/ufl/form.py
+++ b/ufl/form.py
@@ -50,7 +50,7 @@ def _sorted_integrals(integrals):
             )
         it = integral.integral_type()
         si = integral.subdomain_id()
-        integrals_dict[d][it][si] += [integral]
+        integrals_dict[d][it][si].append(integral)
 
     all_integrals = []
 
@@ -586,7 +586,7 @@ class Form(BaseForm):
 
         # TODO: Not including domains from coefficients and arguments
         # here, may need that later
-        self._domain_numbering = dict((d, i) for i, d in enumerate(self._integration_domains))
+        self._domain_numbering = {d: i for i, d in enumerate(self._integration_domains)}
 
     def _analyze_subdomain_data(self):
         """Analyze subdomain data."""

--- a/ufl/indexed.py
+++ b/ufl/indexed.py
@@ -47,7 +47,8 @@ class Indexed(Operator):
 
         try:
             # Simplify indexed ListTensor
-            return expression[multiindex]
+            c = expression[multiindex]
+            return Indexed(*c.ufl_operands) if isinstance(c, Indexed) else c
         except ValueError:
             return Operator.__new__(cls)
 

--- a/ufl/indexed.py
+++ b/ufl/indexed.py
@@ -26,8 +26,7 @@ class Indexed(Operator):
 
     def __new__(cls, expression, multiindex):
         """Create a new Indexed."""
-        indices = multiindex.indices()
-        if len(indices) == 0:
+        if len(multiindex) == 0:
             return expression
         if isinstance(expression, Zero):
             # Zero-simplify indexed Zero objects
@@ -35,7 +34,7 @@ class Indexed(Operator):
             efi = expression.ufl_free_indices
             efid = expression.ufl_index_dimensions
             fi = list(zip(efi, efid))
-            for pos, ind in enumerate(indices):
+            for pos, ind in enumerate(multiindex):
                 if isinstance(ind, Index):
                     fi.append((ind.count(), shape[pos]))
             fi = unique_sorted_indices(sorted(fi))

--- a/ufl/indexed.py
+++ b/ufl/indexed.py
@@ -29,8 +29,9 @@ class Indexed(Operator):
         # cyclic import
         from ufl.tensors import ListTensor
 
-        simpler = False
+        flattened = False
         indices = multiindex.indices()
+
         while (
             len(indices) > 0
             and isinstance(expression, ListTensor)
@@ -39,13 +40,13 @@ class Indexed(Operator):
             # Simplify indexed ListTensor objects
             expression = expression[indices[0]]
             indices = indices[1:]
-            simpler = True
+            flattened = True
 
         if isinstance(expression, Indexed):
             # Simplify nested Indexed objects
             indices = expression.ufl_operands[1].indices() + indices
             expression = expression.ufl_operands[0]
-            simpler = True
+            flattened = True
 
         if len(indices) == 0:
             return expression
@@ -64,7 +65,8 @@ class Indexed(Operator):
             else:
                 fi, fid = (), ()
             return Zero(shape=(), free_indices=fi, index_dimensions=fid)
-        elif simpler:
+        elif flattened:
+            # Simplified Indexed expression
             return Indexed(expression, MultiIndex(indices))
         else:
             return Operator.__new__(cls)

--- a/ufl/indexed.py
+++ b/ufl/indexed.py
@@ -26,13 +26,21 @@ class Indexed(Operator):
 
     def __new__(cls, expression, multiindex):
         """Create a new Indexed."""
+        from ufl.tensors import ListTensor
+
+        indices = multiindex._indices
+        while isinstance(expression, ListTensor) and isinstance(indices[0], FixedIndex):
+            # Simplify indexed ListTensor objects
+            expression = expression[indices[0]]
+            indices = indices[1:]
+
         if isinstance(expression, Zero):
             # Zero-simplify indexed Zero objects
             shape = expression.ufl_shape
             efi = expression.ufl_free_indices
             efid = expression.ufl_index_dimensions
             fi = list(zip(efi, efid))
-            for pos, ind in enumerate(multiindex._indices):
+            for pos, ind in enumerate(indices):
                 if isinstance(ind, Index):
                     fi.append((ind.count(), shape[pos]))
             fi = unique_sorted_indices(sorted(fi))

--- a/ufl/indexed.py
+++ b/ufl/indexed.py
@@ -28,7 +28,7 @@ class Indexed(Operator):
         """Create a new Indexed."""
         from ufl.tensors import ListTensor
 
-        indices = multiindex._indices
+        indices = multiindex.indices()
         while isinstance(expression, ListTensor) and isinstance(indices[0], FixedIndex):
             # Simplify indexed ListTensor objects
             expression = expression[indices[0]]

--- a/ufl/restriction.py
+++ b/ufl/restriction.py
@@ -5,6 +5,7 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
+from ufl.constantvalue import ConstantValue
 from ufl.core.operator import Operator
 from ufl.core.ufl_type import ufl_type
 from ufl.precedence import parstr
@@ -24,7 +25,12 @@ class Restricted(Operator):
 
     __slots__ = ()
 
-    # TODO: Add __new__ operator here, e.g. restricted(literal) == literal
+    def __new__(cls, expression):
+        """Create a new Restricted."""
+        if isinstance(expression, ConstantValue):
+            return expression
+        else:
+            return Operator.__new__(cls)
 
     def __init__(self, f):
         """Initialise."""

--- a/ufl/sobolevspace.py
+++ b/ufl/sobolevspace.py
@@ -111,9 +111,9 @@ class DirectionalSobolevSpace(SobolevSpace):
                 the position denotes in what spatial variable the
                 smoothness requirement is enforced.
         """
-        assert all(
-            isinstance(x, int) or isinf(x) for x in orders
-        ), "Order must be an integer or infinity."
+        assert all(isinstance(x, int) or isinf(x) for x in orders), (
+            "Order must be an integer or infinity."
+        )
         name = "DirectionalH"
         parents = [L2]
         super(DirectionalSobolevSpace, self).__init__(name, parents)

--- a/ufl/tensors.py
+++ b/ufl/tensors.py
@@ -55,7 +55,7 @@ class ListTensor(Operator):
 
         # Simplify to Zero if possible
         if all(isinstance(e, Zero) for e in expressions):
-            shape = (len(expressions),) + sh
+            shape = (len(expressions), *sh)
             return Zero(shape, fi, fid)
 
         # Simplify [v[0], v[1], ..., v[k]] -> v
@@ -132,7 +132,7 @@ class ListTensor(Operator):
                 s = (",\n" + ind).join(substrings)
                 return "%s[\n%s%s\n%s]" % (ind, ind, s, ind)
             else:
-                s = ", ".join(str(e) for e in expressions)
+                s = ", ".join(map(str, expressions))
                 return "%s[%s]" % (ind, s)
 
         return substring(self.ufl_operands, 0)


### PR DESCRIPTION
When splitting mixed Forms, mixed Arguments get replaced by ListTensors of Zero and subspace Arguments of the form `[0,  ..., 0, v[0], ..., v[k],  0, ..., 0]`. The resulting split Form would contain many instances of Indexed objects with this ListTensor, that could be simplified to either `0` or `[v[0], ..., v[k]] -> v`. 

Previously, the simplification step was left as a task for the form compiler, but working with such complicated expressions often results in sub-optimal code generation. This PR addresses the following simplications at the UFL-level:

1. `Indexed(ListTensor[v0, ..., vk], (j,)) -> vj`
2. `ListTensor(Indexed(v, FixedIndex(i)) for i in range(k)) -> v`
3. `Restricted(ConstantValue) -> ConstantValue`

As a consequence, splitting a bilinear Form with a block in the diagonal equal to zero produces an empty Form, losing all the information that the unsimplified Form carried around, such as the Arguments and the arity. This situation needs to be handled carefully as a special case. See https://github.com/firedrakeproject/firedrake/pull/3947

With these simplifications, we can correctly estimate quadrature degrees for integrands that only depend on one component of the solution, thus lowering flop counts.