### PR TITLE
Return ZeroBaseForm for zero derivative

### DIFF
--- a/test/test_external_operator.py
+++ b/test/test_external_operator.py
@@ -31,7 +31,7 @@ from ufl.algorithms import expand_derivatives
 from ufl.algorithms.apply_derivatives import apply_derivatives
 from ufl.core.external_operator import ExternalOperator
 from ufl.finiteelement import FiniteElement
-from ufl.form import BaseForm
+from ufl.form import BaseForm, ZeroBaseForm
 from ufl.pullback import identity_pullback
 from ufl.sobolevspace import H1
 
@@ -516,3 +516,10 @@ def test_replace(V1):
 
     dN_replaced = dN._ufl_expr_reconstruct_(u, argument_slots=(A, uhat))
     assert G == dN_replaced
+
+
+def test_ZeroDerivative(V1):
+    u = Coefficient(V1, count=1)
+    N = ExternalOperator(Coefficient(V1, count=0), function_space=V1)
+    dN1 = expand_derivatives(derivative(N, u))
+    assert isinstance(dN1, ZeroBaseForm)

--- a/ufl/algorithms/apply_derivatives.py
+++ b/ufl/algorithms/apply_derivatives.py
@@ -1314,7 +1314,7 @@ class BaseFormOperatorDerivativeRuleset(GateauxDerivativeRuleset):
                     *N.ufl_operands, derivatives=derivatives, argument_slots=new_args
                 )
             elif df == 0:
-                extop = Zero(N.ufl_shape)
+                extop = ZeroBaseForm(N.arguments())
             else:
                 raise NotImplementedError(
                     "Frechet derivative of external operators need to be provided!"
@@ -1401,8 +1401,6 @@ class DerivativeRuleDispatcher(MultiFunction):
             return ZeroBaseForm(arguments)
         # We need to go through the dag first to record the pending operations
         mapped_expr = map_expr_dag(rules, f, vcache=self.vcaches[key], rcache=self.rcaches[key])
-        if isinstance(mapped_expr, Zero):
-            mapped_expr = ZeroBaseForm(f.arguments())
         mapped_f = rules.coefficient(f)
         if mapped_f != 0:
             # If dN/dN needs to return an Argument in N space

--- a/ufl/algorithms/apply_derivatives.py
+++ b/ufl/algorithms/apply_derivatives.py
@@ -1401,6 +1401,7 @@ class DerivativeRuleDispatcher(MultiFunction):
             return ZeroBaseForm(arguments)
         # We need to go through the dag first to record the pending operations
         mapped_expr = map_expr_dag(rules, f, vcache=self.vcaches[key], rcache=self.rcaches[key])
+
         mapped_f = rules.coefficient(f)
         if mapped_f != 0:
             # If dN/dN needs to return an Argument in N space

--- a/ufl/algorithms/apply_derivatives.py
+++ b/ufl/algorithms/apply_derivatives.py
@@ -1401,7 +1401,8 @@ class DerivativeRuleDispatcher(MultiFunction):
             return ZeroBaseForm(arguments)
         # We need to go through the dag first to record the pending operations
         mapped_expr = map_expr_dag(rules, f, vcache=self.vcaches[key], rcache=self.rcaches[key])
-
+        if isinstance(mapped_expr, Zero):
+            mapped_expr = ZeroBaseForm(f.arguments())
         mapped_f = rules.coefficient(f)
         if mapped_f != 0:
             # If dN/dN needs to return an Argument in N space


### PR DESCRIPTION
The line code:  

```python
mapped_expr = map_expr_dag(rules, f, vcache=self.vcaches[key], rcache=self.rcaches[key])
```  
at `DerivativeRuleDispatcher.base_form_operator_derivative` currently returns `ufl.constantvalue.Zero` when the derivative is zero. This can lead to errors, for example in Firedrake assembly, which expects a form with an associated function space.  

This PR ensures that, when the derivative is zero, `ZeroBaseForm` is returned instead.