### PR TITLE
Fix replace_derivative_nodes

### DIFF
--- a/ufl/algorithms/replace_derivative_nodes.py
+++ b/ufl/algorithms/replace_derivative_nodes.py
@@ -17,7 +17,7 @@ class DerivativeNodeReplacer(MultiFunction):
         self.mapping = mapping
         self.der_kwargs = derivative_kwargs
 
-    expr = MultiFunction.reuse_if_untouched
+    ufl_type = MultiFunction.reuse_if_untouched
 
     def coefficient_derivative(self, cd, o, coefficients, arguments, coefficient_derivatives):
         """Apply to coefficient_derivative."""


### PR DESCRIPTION
Fixes https://github.com/firedrakeproject/firedrake/issues/4120

This PR implements coefficient derivatives on more generic ufl types such as `Cofunctions`.

Inspired from `DerivativeRuleDispatcher`, the right thing would be https://github.com/FEniCS/ufl/blob/069f07810dc13fa69ecda6f7ad6de41bc287f367/ufl/algorithms/apply_derivatives.py#L1454