### PR TITLE
add DAGTraverser class and remove MultiFunctions in apply_derivatives()

### DIFF
--- a/ufl/corealg/dag_traverser.py
+++ b/ufl/corealg/dag_traverser.py
@@ -1,0 +1,128 @@
+"""Base class for dag traversers."""
+
+from functools import singledispatchmethod, wraps
+from typing import Union
+
+from ufl.classes import Expr
+
+
+class DAGTraverser:
+    """Base class for DAG traversers.
+
+    Args:
+        compress: If True, ``result_cache`` will be used.
+        visited_cache: cache of intermediate results; expr -> r = self.process(expr, ...).
+        result_cache: cache of result objects for memory reuse, r -> r.
+
+    """
+
+    def __init__(
+        self,
+        compress: Union[bool, None] = True,
+        visited_cache: Union[dict[tuple, Expr], None] = None,
+        result_cache: Union[dict[Expr, Expr], None] = None,
+    ) -> None:
+        """Initialise."""
+        self._compress = compress
+        self._visited_cache = {} if visited_cache is None else visited_cache
+        self._result_cache = {} if result_cache is None else result_cache
+
+    def __call__(self, node: Expr, *args) -> Expr:
+        """Perform memoised DAG traversal with ``process`` singledispatch method.
+
+        Args:
+            node: `Expr` to start DAG traversal from.
+            args: arguments to the ``process`` singledispatchmethod.
+
+        Returns:
+            Processed `Expr`.
+
+        """
+        cache_key = (node, *args)
+        try:
+            return self._visited_cache[cache_key]
+        except KeyError:
+            result = self.process(node, *args)
+            # Optionally check if r is in result_cache, a memory optimization
+            # to be able to keep representation of result compact
+            if self._compress:
+                try:
+                    # Cache hit: Use previously computed object, allowing current
+                    # ``result`` to be garbage collected as soon as possible
+                    result = self._result_cache[result]
+                except KeyError:
+                    # Cache miss: store in result_cache
+                    self._result_cache[result] = result
+            # Store result in cache
+            self._visited_cache[cache_key] = result
+            return result
+
+    @singledispatchmethod
+    def process(self, o: Expr, *args) -> Expr:
+        """Process node by type.
+
+        Args:
+            o: `Expr` to start DAG traversal from.
+            args: arguments to the ``process`` singledispatchmethod.
+
+        Returns:
+            Processed `Expr`.
+
+        """
+        raise AssertionError(f"Rule not set for {type(o)}")
+
+    def reuse_if_untouched(self, o: Expr) -> Expr:
+        """Reuse if touched.
+
+        Args:
+            o: `Expr` to start DAG traversal from.
+            new_ufl_operands: new ufl_operands of ``o``.
+
+        Returns:
+            Processed `Expr`.
+
+        """
+        new_ufl_operands = [self(operand) for operand in o.ufl_operands]
+        if all(nc == c for nc, c in zip(new_ufl_operands, o.ufl_operands)):
+            return o
+        else:
+            return o._ufl_expr_reconstruct_(*new_ufl_operands)
+
+    @staticmethod
+    def postorder(method):
+        """Postorder decorator.
+
+        It is more natural for users to write a post-order singledispatchmethod
+        whose arguments are ``(self, o, *processed_operands, *additional_args)``,
+        while `DAGTraverser` expects one whose arguments are
+        ``(self, o, *additional_args)``.
+        This decorator takes the former and converts the latter, processing
+        ``o.ufl_operands`` behind the users.
+
+        """
+
+        @wraps(method)
+        def wrapper(self, o, *args):
+            processed_operands = [self(operand) for operand in o.ufl_operands]
+            return method(self, o, *processed_operands, *args)
+
+        return wrapper
+
+    @staticmethod
+    def postorder_only_children(indices):
+        """Postorder decorator with child indices.
+
+        This decorator is the same as `DAGTraverser.postorder` except that the
+        decorated method is only to take processed operands corresponding to ``indices``.
+
+        """
+
+        def postorder(method):
+            @wraps(method)
+            def wrapper(self, o, *args):
+                processed_operands = [self(o.ufl_operands[i]) for i in indices]
+                return method(self, o, *processed_operands, *args)
+
+            return wrapper
+
+        return postorder


### PR DESCRIPTION
Attempt to implement what @wence- described in [this issue](https://github.com/FEniCS/ufl/issues/35).

We basically would like to introduce classes (`DAGTraverser`s) that define node processing (using `singledispatchmethod`) and hold caches.

We considered two DAG traversal approaches (for post-order and mostly post-order traversals).

**Approach 1. Two-step approach.**

Collect nodes first post-order and then process them in order.

This is the current UFL approach (`cutoff_unique_post_traversal` + `MultiFunction` wrapped in `map_expr_dags`).

This "bottom-up" approach is optimal, but when we process a node, we no longer know the local DAG structure around that node (e.g., we do not know its parent). So if we want to pass down some state from the parent, we need to (indirectly) specify that that parent is a "cutoff" node (so that we do not collect the child nodes in the first step), and perform a sub-DAG traversal under that parent; see [RestrictionPropagator.restricted(self, o)](https://github.com/FEniCS/ufl/blob/b002eb0e815f74c8ed9ca3b53aa77e2d2486f062/ufl/algorithms/apply_restrictions.py#L40). In the current implementation, if the number of arguments to the method is two (`self` and `o` in the above case), the corresponding node type is regarded as a cutoff node type. `MultiFunction` constructor currently identifies cutoff node types by `inspect`ing the signature of each method. If we wanted to do a similar thing with `singledispatchmethod`, we could subclass `singledispatchmethod` as David suggested, but we found that we would end up overwriting `singledispatchmethod.register()` method relying on the current implementation of `singledispatchmethod`, which would be a drawback.

**Approach 2. Monolithic approach.**

Use recursion with caching (each node is processed once and only once) described in [this issue](https://github.com/FEniCS/ufl/issues/35).

I observed about a few % - 20% overhead after rewriting `apply_derivatives.py` (please see below) presumably due to recursion, but no special consideration of cutoff is required. This approach is claimed to be more robust.

##

In this PR we take Approach2, and replace `MultiFunction` s with `DAGTraverser`s in `apply_derivatives.py`. We should be able to incrementally/systematically remove all `MultiFunction`s in the future.

Performance checks:

**`holzapfel_ogden.py`** ([holzapfel_ogden](https://gist.github.com/FabioLuporini/a74baa84b64fd1c08f5eb9cc45c8ea7e)):
```
import time

from ufl import (
    Coefficient,
    Constant,
    FunctionSpace,
    Identity,
    Mesh,
    TestFunction,
    derivative,
    det,
    diff,
    dot,
    dx,
    exp,
    grad,
    inner,
    ln,
    tetrahedron,
    tr,
    variable,
)
from ufl.algorithms import compute_form_data
from ufl.finiteelement import FiniteElement
from ufl.pullback import identity_pullback
from ufl.sobolevspace import H1


mesh = Mesh(FiniteElement("Lagrange", tetrahedron, 1, (3,), identity_pullback, H1))
lamda = Constant(mesh)
a = Constant(mesh)
b = Constant(mesh)
a_s = Constant(mesh)
b_s = Constant(mesh)
a_f = Constant(mesh)
b_f = Constant(mesh)
a_fs = Constant(mesh)
b_fs = Constant(mesh)
e_s = Constant(mesh, shape=(3,))
e_f = Constant(mesh, shape=(3,))

def isochoric(F):
    C = F.T*F
    I_1 = tr(C)
    I4_f = dot(e_f, C*e_f)
    I4_s = dot(e_s, C*e_s)
    I8_fs = dot(e_f, C*e_s)

    def cutoff(x):
        return 1.0/(1.0 + exp(-(x - 1.0)*30.0))

    def scaled_exp(a0, a1, argument):
        return a0/(2.0*a1)*(exp(b*argument) - 1)

    def scaled_exp(a0, a1, argument):
        return a0/(2.0*a1)*(exp(b*argument) - 1)

    E_1 = scaled_exp(a, b, I_1 - 3.)
    E_f = cutoff(I4_f)*scaled_exp(a_f, b_f, (I4_f - 1.)**2)
    E_s = cutoff(I4_s)*scaled_exp(a_s, b_s, (I4_s - 1.)**2)
    E_3 = scaled_exp(a_fs, b_fs, I8_fs**2)
    E = E_1 + E_f + E_s + E_3
    return E

elem = FiniteElement("Lagrange", tetrahedron, 1, (3,), identity_pullback, H1)
V = FunctionSpace(mesh, elem)
u = Coefficient(V)
v = TestFunction(V)
I = Identity(mesh.ufl_cell().topological_dimension())
F = grad(u) + I
F = variable(F)
J = det(F)
Fbar = J**(-1.0/3.0)*F
E_volumetric = lamda*0.5*ln(J)**2
psi = isochoric(Fbar) + E_volumetric
P = diff(psi, F)
F = inner(P, grad(v))*dx
a = derivative(F, u)

ntest = 2
time_sum = 0
for _ in range(ntest):
    start = time.time()
    fd = compute_form_data(
        a,
        do_apply_function_pullbacks=True,
        do_apply_default_restrictions=True,
        do_apply_geometry_lowering=True,
        do_apply_restrictions=True,
        complex_mode=False,
    )
    end = time.time()
    time_sum += end - start
print("average time required: ", time_sum / ntest)
```
`main`:
average time required:  0.27037227153778076

`this PR`:
average time required:  0.27785348892211914 (+2.8%)

With https://github.com/FEniCS/ufl/pull/339 (<- performance regression) reverted:

`main`:
average time required:  0.04610729217529297

`this PR`:
average time required:  0.055258870124816895 (+20%)


**`wence_test`** (https://github.com/FEniCS/ufl/pull/69):
```
import time

from ufl import (
    Coefficient,
    Constant,
    FacetNormal,
    FunctionSpace,
    Identity,
    Mesh,
    avg,
    derivative,
    det,
    diff,
    dS,
    grad,
    hexahedron,
    inner,
    ln,
    outer,
    variable,
)
from ufl.algorithms import compute_form_data
from ufl.finiteelement import FiniteElement
from ufl.pullback import identity_pullback, contravariant_piola
from ufl.sobolevspace import H1, HDiv

cell = hexahedron
mesh = Mesh(FiniteElement("Q", cell, 1, (3,), identity_pullback, H1))
V = FunctionSpace(mesh, FiniteElement("NCF", cell, 2, (3,), contravariant_piola, HDiv))
u = Coefficient(V)
mu = Constant(mesh)
psi = lambda F: (mu/2) * (inner(F, F) - u.ufl_shape[0]) - mu*ln(det(F))
flux = lambda F: diff(psi(F), F)
n = FacetNormal(mesh)
uxn = outer(u('+'), n('+')) + outer(u('-'), n('-'))
eye = Identity(u.ufl_shape[0])
grad_u = grad(u)
F_ = variable(grad_u + eye)
Fm = variable(grad_u('-') + eye)
Fp = variable(grad_u('+') + eye)
avg_flux = avg(flux(F_))
U = inner(avg_flux, uxn)*dS
a = derivative(derivative(U, u), u)

ntest = 2
time_sum = 0
for _ in range(ntest):
    start = time.time()
    fd = compute_form_data(
        a,
        do_apply_function_pullbacks=True,
        do_apply_default_restrictions=True,
        do_apply_geometry_lowering=True,
        do_apply_restrictions=True,
        complex_mode=False,
    )
    end = time.time()
    time_sum += end - start
print("average time required: ", time_sum / ntest)
```
`main`:
average time required:  0.23360061645507812

`this PR`:
average time required:  0.2485201358795166 (+6.4%)

With https://github.com/FEniCS/ufl/pull/339 reverted:

`main`:
average time required:  0.060405850410461426

`this PR`:
average time required:  0.06431174278259277 (+6.5%)


**Firedrake CI**
https://github.com/firedrakeproject/firedrake/pull/4145 (no notable performance regression).
