### PR TITLE
Update Python versions

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -24,9 +24,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        exclude:
-          - os: macos-latest
-            python-version: '3.9'
         include:
           - os: windows-latest
             python-version: '3.11'

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -22,11 +22,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        include:
-          - os: windows-latest
-            python-version: '3.11'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -23,7 +23,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        exclude:
           - os: macos-latest
             python-version: '3.9'
         include:

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -23,10 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        exclude:
-          - os: macos-latest
-            python-version: '3.8'
+        python-version: ['3.9', '3.10', '3.11', '3.12']
           - os: macos-latest
             python-version: '3.9'
         include:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ maintainers = [
 description = "Unified Form Language"
 readme = "README.md"
 license = { file = "COPYING.lesser" }
-requires-python = ">=3.8.0"
+requires-python = ">=3.9.0"
 dependencies = ["numpy"]
 
 [project.urls]


### PR DESCRIPTION
Python 3.8 has reached EOL and 3.13 is officially released, see https://devguide.python.org/versions/.

Therefore bumping to at least 3.9 and testing up to 3.13. Includes/Excludes of test cases in the CI matrix seem to be no longer necessary and are removed. 