### PR TITLE
remove_compoment_tensors: fix performance regression

### DIFF
--- a/test/test_algorithms.py
+++ b/test/test_algorithms.py
@@ -194,6 +194,6 @@ def test_remove_component_tensors(domain):
     f = div(grad(div(grad(u))))
     form = f * dx
 
-    fd = compute_form_data(form)
+    fd = compute_form_data(form, do_remove_component_tensors=True)
 
     assert "ComponentTensor" not in repr(fd.preprocessed_form)

--- a/test/test_derivative.py
+++ b/test/test_derivative.py
@@ -665,7 +665,7 @@ def test_vector_coefficient_scalar_derivatives(self):
     integrand = inner(f, g)
 
     i0, i1, i2, i3, i4 = [Index(count=c) for c in range(5)]
-    expected = as_tensor(df[i1], (i1,))[i0] * dv * g[i0]
+    expected = as_tensor(df[i1] * dv, (i1,))[i0] * g[i0]
 
     F = integrand * dx
     J = derivative(F, u, dv, cd)
@@ -693,7 +693,7 @@ def test_vector_coefficient_derivatives(self):
     integrand = inner(f, g)
 
     i0, i1, i2, i3, i4 = [Index(count=c) for c in range(5)]
-    expected = as_tensor(df[i2, i1], (i2,))[i0] * dv[i1] * g[i0]
+    expected = as_tensor(df[i2, i1] * dv[i1], (i2,))[i0] * g[i0]
 
     F = integrand * dx
     J = derivative(F, u, dv, cd)

--- a/ufl/algorithms/compute_form_data.py
+++ b/ufl/algorithms/compute_form_data.py
@@ -339,9 +339,6 @@ def compute_form_data(
 
     form = apply_coordinate_derivatives(form)
 
-    # Remove component tensors
-    form = remove_component_tensors(form)
-
     # Propagate restrictions to terminals
     if do_apply_restrictions:
         form = apply_restrictions(form, apply_default=do_apply_default_restrictions)
@@ -349,6 +346,9 @@ def compute_form_data(
     # If in real mode, remove any complex nodes introduced during form processing.
     if not complex_mode:
         form = remove_complex_nodes(form)
+
+    # Remove component tensors
+    form = remove_component_tensors(form)
 
     # --- Group integrals into IntegralData objects
     # Most of the heavy lifting is done above in group_form_integrals.

--- a/ufl/algorithms/compute_form_data.py
+++ b/ufl/algorithms/compute_form_data.py
@@ -258,6 +258,7 @@ def compute_form_data(
     do_estimate_degrees=True,
     do_append_everywhere_integrals=True,
     complex_mode=False,
+    do_remove_component_tensors=False,
 ):
     """Compute form data.
 
@@ -348,7 +349,8 @@ def compute_form_data(
         form = remove_complex_nodes(form)
 
     # Remove component tensors
-    form = remove_component_tensors(form)
+    if do_remove_component_tensors:
+        form = remove_component_tensors(form)
 
     # --- Group integrals into IntegralData objects
     # Most of the heavy lifting is done above in group_form_integrals.

--- a/ufl/algorithms/remove_component_tensors.py
+++ b/ufl/algorithms/remove_component_tensors.py
@@ -13,30 +13,24 @@ from collections import defaultdict
 from ufl.algorithms.map_integrands import map_integrand_dags
 from ufl.classes import ComponentTensor, Index, MultiIndex, Zero
 from ufl.corealg.map_dag import map_expr_dag
-from ufl.corealg.multifunction import MultiFunction, memoized_handler
+from ufl.corealg.multifunction import MultiFunction
 
 
 class IndexReplacer(MultiFunction):
     """Replace Indices."""
 
-    def __init__(self, fimap: dict, object_cache=None):
+    def __init__(self, fimap: dict):
         """Initialise.
 
         Args:
            fimap: map for index replacements.
-           object_cache: a dict to cache objects.
 
         """
         MultiFunction.__init__(self)
         self.fimap = fimap
-        self._object_cache = object_cache or {}
-        # caches for reuse in the dispatched transformers
-        self.vcaches = defaultdict(dict)
-        self.rcaches = defaultdict(dict)
 
     expr = MultiFunction.reuse_if_untouched
 
-    @memoized_handler
     def zero(self, o):
         """Handle Zero."""
         indices = tuple(map(Index, o.ufl_free_indices))
@@ -52,18 +46,12 @@ class IndexReplacer(MultiFunction):
                 free_indices.append(j.count())
                 index_dimensions.append(d)
 
-        key = (type(o), tuple(free_indices), tuple(index_dimensions))
-        r = self._object_cache.get(key)
-        if r is None:
-            r = Zero(
-                shape=o.ufl_shape,
-                free_indices=tuple(free_indices),
-                index_dimensions=tuple(index_dimensions),
-            )
-            self._object_cache[key] = r
-        return r
+        return Zero(
+            shape=o.ufl_shape,
+            free_indices=tuple(free_indices),
+            index_dimensions=tuple(index_dimensions),
+        )
 
-    @memoized_handler
     def multi_index(self, o):
         """Handle MultiIndex."""
         if not any(i in self.fimap for i in o):
@@ -71,13 +59,7 @@ class IndexReplacer(MultiFunction):
             return o
 
         indices = tuple(self.fimap.get(i, i) for i in o)
-
-        key = (type(o), *_cache_key(indices))
-        r = self._object_cache.get(key)
-        if r is None:
-            r = MultiIndex(indices)
-            self._object_cache[key] = r
-        return r
+        return MultiIndex(indices)
 
 
 class IndexRemover(MultiFunction):
@@ -87,51 +69,39 @@ class IndexRemover(MultiFunction):
         """Initialise."""
         MultiFunction.__init__(self)
         self.rules = {}
-        self.ocache = {}
-        self.rcache = {}
+        # caches for reuse in the dispatched transformers
+        self.vcaches = defaultdict(dict)
+        self.rcaches = defaultdict(dict)
 
-    ufl_type = MultiFunction.reuse_if_untouched
+    expr = MultiFunction.reuse_if_untouched
 
     def indexed(self, o, o1, i1):
         """Simplify Indexed."""
-        ckey = (o1, i1)
-        result = self.rcache.get(ckey)
-        if result is not None:
-            return result
-
         if isinstance(o1, ComponentTensor):
             # Simplify Indexed ComponentTensor
             o2, i2 = o1.ufl_operands
-
             # Replace outer indices
-            rkey = (_cache_key(i2), _cache_key(i1))
+            rkey = (i2, i1)
             rule = self.rules.get(rkey)
             if rule is None:
                 # NOTE: Replace with `fimap = dict(zip(i2, i1, strict=True))` when
                 # Python>=3.10
                 assert len(i2) == len(i1)
                 fimap = dict(zip(i2, i1))
-                rule = IndexReplacer(fimap, object_cache=self.ocache)
+                rule = IndexReplacer(fimap)
                 self.rules[rkey] = rule
 
-            key = (IndexReplacer, o2)
-            result = map_expr_dag(rule, o2, vcache=rule.vcaches[key], rcache=rule.rcaches[key])
-            return self.rcache.setdefault(ckey, result)
+            key = (IndexReplacer, *rkey)
+            return map_expr_dag(rule, o2, vcache=self.vcaches[key], rcache=self.rcaches[key])
 
-        if o.ufl_operands[0] is o1:
+        elif o.ufl_operands[0] is o1:
             # Reuse if untouched
-            result = o
+            return o
         else:
-            result = o._ufl_expr_reconstruct_(o1, i1)
-        return self.rcache.setdefault(ckey, result)
+            return o._ufl_expr_reconstruct_(o1, i1)
 
 
 def remove_component_tensors(o):
     """Remove component tensors."""
     rule = IndexRemover()
     return map_integrand_dags(rule, o)
-
-
-def _cache_key(multiindex):
-    """Return a cache key for a MultiIndex."""
-    return tuple((type(j), j.count() if isinstance(j, Index) else int(j)) for j in multiindex)

--- a/ufl/conditional.py
+++ b/ufl/conditional.py
@@ -13,6 +13,7 @@ from ufl.core.expr import ufl_err_str
 from ufl.core.operator import Operator
 from ufl.core.ufl_type import ufl_type
 from ufl.exprequals import expr_equals
+from ufl.indexed import Indexed
 from ufl.precedence import parstr
 
 # --- Condition classes ---
@@ -269,7 +270,7 @@ class Conditional(Operator):
     def __new__(cls, condition, true_value, false_value):
         """Create a new Conditional."""
         # Simplify
-        if bool(true_value == false_value):
+        if (true_value is false_value) or bool(true_value == false_value):
             return true_value
         # Construct a new instance to be initialised
         self = Operator.__new__(cls)
@@ -291,7 +292,7 @@ class Conditional(Operator):
             raise ValueError("Shape mismatch between conditional branches.")
         tfi = true_value.ufl_free_indices
         ffi = false_value.ufl_free_indices
-        if tfi != ffi:
+        if tuple(sorted(tfi)) != tuple(sorted(ffi)):
             raise ValueError("Free index mismatch between conditional branches.")
         if isinstance(condition, (EQ, NE)):
             if not all(
@@ -305,6 +306,10 @@ class Conditional(Operator):
                 raise ValueError("Non-scalar == or != is not allowed.")
         Operator.__init__(self, (condition, true_value, false_value))
         self._initialised = True
+
+    def _simplify_indexed(self, multiindex):
+        (c, a, b) = self.ufl_operands
+        return Conditional(c, Indexed(a, multiindex), Indexed(b, multiindex))
 
     def evaluate(self, x, mapping, component, index_values):
         """Evaluate."""

--- a/ufl/conditional.py
+++ b/ufl/conditional.py
@@ -270,7 +270,7 @@ class Conditional(Operator):
     def __new__(cls, condition, true_value, false_value):
         """Create a new Conditional."""
         # Simplify
-        if (true_value is false_value) or bool(true_value == false_value):
+        if bool(true_value == false_value):
             return true_value
         # Construct a new instance to be initialised
         self = Operator.__new__(cls)

--- a/ufl/exprequals.py
+++ b/ufl/exprequals.py
@@ -20,14 +20,15 @@ def expr_equals(self, other):
         return False
 
     # Large objects are costly to compare with themselves
-    if self is other:
+    if self is other or self.ufl_operands is other.ufl_operands:
         return True
 
     # Modelled after pre_traversal to avoid recursion:
     left = [(self, other)]
+    equal_pairs = set()
     while left:
-        s, o = left.pop()
-
+        pair = left.pop()
+        s, o = pair
         if s._ufl_is_terminal_:
             # Compare terminals
             if not s == o:
@@ -36,6 +37,9 @@ def expr_equals(self, other):
             # Delve into subtrees
             so = s.ufl_operands
             oo = o.ufl_operands
+            # Skip subtrees if operands are the same
+            if so is oo:
+                continue
             if len(so) != len(oo):
                 return False
 
@@ -46,8 +50,13 @@ def expr_equals(self, other):
                 # Skip subtree if objects are the same
                 if s is o:
                     continue
+                if (s, o) in equal_pairs:
+                    continue
                 # Append subtree for further inspection
                 left.append((s, o))
+
+        # Keep track of equal subexpressions
+        equal_pairs.add(pair)
 
     # Equal if we get out of the above loop!
     # Eagerly DAGify to reduce the size of the tree.

--- a/ufl/exprequals.py
+++ b/ufl/exprequals.py
@@ -48,7 +48,7 @@ def expr_equals(self, other):
                 if s._ufl_typecode_ != o._ufl_typecode_:
                     return False
                 # Skip subtree if objects are the same
-                if s is o:
+                if s is o or s.ufl_operands is o.ufl_operands:
                     continue
                 if (s, o) in equal_pairs:
                     continue

--- a/ufl/exprequals.py
+++ b/ufl/exprequals.py
@@ -50,13 +50,13 @@ def expr_equals(self, other):
                 # Skip subtree if objects are the same
                 if s is o or s.ufl_operands is o.ufl_operands:
                     continue
-                if (s, o) in equal_pairs:
+                if (id(s), id(o)) in equal_pairs:
                     continue
                 # Append subtree for further inspection
                 left.append((s, o))
 
         # Keep track of equal subexpressions
-        equal_pairs.add(pair)
+        equal_pairs.add((id(pair[0]), id(pair[1])))
 
     # Equal if we get out of the above loop!
     # Eagerly DAGify to reduce the size of the tree.

--- a/ufl/sorting.py
+++ b/ufl/sorting.py
@@ -140,6 +140,9 @@ def cmp_expr(a, b):
             # Delve into subtrees
             aops = a.ufl_operands
             bops = b.ufl_operands
+            # Skip subtrees if operands are the same
+            if aops is bops:
+                continue
 
             # Sort by children in natural order
             for r, s in zip(aops, bops):

--- a/ufl/sorting.py
+++ b/ufl/sorting.py
@@ -108,9 +108,10 @@ def cmp_expr(a, b):
     """Replacement for cmp(a, b), removed in Python 3, for Expr objects."""
     # Modelled after pre_traversal to avoid recursion:
     left = [(a, b)]
+    equal_pairs = set()
     while left:
-        a, b = left.pop()
-
+        pair = left.pop()
+        a, b = pair
         # First sort quickly by type code
         x, y = a._ufl_typecode_, b._ufl_typecode_
         if x != y:
@@ -145,6 +146,8 @@ def cmp_expr(a, b):
                 # Skip subtree if objects are the same
                 if r is s:
                     continue
+                if (r, s) in equal_pairs:
+                    continue
                 # Append subtree for further inspection
                 left.append((r, s))
 
@@ -157,6 +160,9 @@ def cmp_expr(a, b):
             x, y = len(aops), len(bops)
             if x != y:
                 return -1 if x < y else 1
+
+        # Keep track of equal subexpressions
+        equal_pairs.add(pair)
 
     # Equal if we get out of the above loop!
     return 0

--- a/ufl/sorting.py
+++ b/ufl/sorting.py
@@ -106,12 +106,15 @@ _terminal_cmps[Label._ufl_typecode_] = _cmp_label
 
 def cmp_expr(a, b):
     """Replacement for cmp(a, b), removed in Python 3, for Expr objects."""
+    if a is b:
+        return 0
     # Modelled after pre_traversal to avoid recursion:
     left = [(a, b)]
     equal_pairs = set()
     while left:
         pair = left.pop()
         a, b = pair
+
         # First sort quickly by type code
         x, y = a._ufl_typecode_, b._ufl_typecode_
         if x != y:
@@ -151,6 +154,7 @@ def cmp_expr(a, b):
                     continue
                 if (id(r), id(s)) in equal_pairs:
                     continue
+
                 # Append subtree for further inspection
                 left.append((r, s))
 

--- a/ufl/sorting.py
+++ b/ufl/sorting.py
@@ -149,7 +149,7 @@ def cmp_expr(a, b):
                 # Skip subtree if objects are the same
                 if r is s:
                     continue
-                if (r, s) in equal_pairs:
+                if (id(r), id(s)) in equal_pairs:
                     continue
                 # Append subtree for further inspection
                 left.append((r, s))
@@ -165,7 +165,7 @@ def cmp_expr(a, b):
                 return -1 if x < y else 1
 
         # Keep track of equal subexpressions
-        equal_pairs.add(pair)
+        equal_pairs.add((id(pair[0]), id(pair[1])))
 
     # Equal if we get out of the above loop!
     return 0

--- a/ufl/tensors.py
+++ b/ufl/tensors.py
@@ -61,11 +61,15 @@ class ListTensor(Operator):
                 e = e.ufl_operands[i]
             return e
 
+        def sub_equals(exprs, *indices):
+            sube0 = sub(exprs[0], *indices)
+            return all(sub(e, *indices) is sube0 for e in exprs[1:])
+
         # Simplify [v[j,0], v[j,1], ...., v[j,k]] -> v[j,:]
         if (
             all(isinstance(e, Indexed) for e in expressions)
             and sub(e0, 0).ufl_shape[-1] == len(expressions)
-            and all(sub(e, 0) == sub(e0, 0) for e in expressions[1:])
+            and sub_equals(expressions, 0)
         ):
             indices = [sub(e, 1).indices() for e in expressions]
             try:
@@ -81,7 +85,7 @@ class ListTensor(Operator):
                 for e in expressions
             )
             and sub(e0, 0, 0).ufl_shape[0] == len(expressions)
-            and all(sub(e, 0, 0) == sub(e0, 0, 0) for e in expressions[1:])
+            and sub_equals(expressions, 0, 0)
         ):
             indices = [sub(e, 0, 1).indices() for e in expressions]
             if all(


### PR DESCRIPTION
This PR makes `remove_component_tensors` introduced in https://github.com/FEniCS/ufl/pull/339 an optional step in `compute_form_data`, and disables it by default. Moreover, we also fix a performance regeression (the tree was exploding as unchanged nodes were recreated).

This preprocessing step was creating new multi indices even if they didn't change, which made the dag traversal very expensive. 

Here we introduce reuse of unchanged multi indices and shared caching for the internal rules dispatched by `IndexRemover`. 

We also add a few optimizations to exit early and memoize partial results for equality and comparison of expressions.