### PR TITLE
GateauxDerivativeRuleset return zero of the correct shape

### DIFF
--- a/test/test_derivative.py
+++ b/test/test_derivative.py
@@ -60,7 +60,7 @@ from ufl.algorithms.apply_algebra_lowering import apply_algebra_lowering
 from ufl.algorithms.apply_derivatives import apply_derivatives
 from ufl.algorithms.apply_geometry_lowering import apply_geometry_lowering
 from ufl.classes import Indexed, MultiIndex, ReferenceGrad
-from ufl.constantvalue import as_ufl
+from ufl.constantvalue import Zero, as_ufl
 from ufl.domain import extract_unique_domain
 from ufl.finiteelement import FiniteElement, MixedElement
 from ufl.pullback import identity_pullback
@@ -902,6 +902,39 @@ def test_index_simplification_reference_grad(self):
     assert expr.ufl_shape == ()
 
 
+def test_zero_shape(self):
+    cell = triangle
+    shape = (2, 3, 4)
+    P1 = FiniteElement("Lagrange", cell, 1, shape, identity_pullback, H1)
+    domain = Mesh(FiniteElement("Lagrange", cell, 1, (2,), identity_pullback, H1))
+    V = FunctionSpace(domain, P1)
+    v = TestFunction(V)
+    u = Coefficient(V)
+    w = Coefficient(V)
+
+    (i,) = indices(1)
+    z = zero(shape)
+    zi = z[:, i, :]
+    wi = w[:, i, :]
+    assert isinstance(zi, Zero)
+    assert wi.ufl_shape == (shape[0], shape[-1])
+    assert wi.ufl_shape == zi.ufl_shape
+
+    a = derivative(conditional(u[0, 0, 0] < 1, zi, wi), u, v)
+    assert not isinstance(a, Zero)
+
+    assert a.ufl_shape == zi.ufl_shape
+    assert a.ufl_free_indices == zi.ufl_free_indices
+    assert a.ufl_index_dimensions == zi.ufl_index_dimensions
+
+    expr = apply_derivatives(apply_geometry_lowering(apply_algebra_lowering(a)))
+
+    assert isinstance(expr, Zero)
+    assert expr.ufl_shape == a.ufl_shape
+    assert expr.ufl_free_indices == a.ufl_free_indices
+    assert expr.ufl_index_dimensions == a.ufl_index_dimensions
+
+
 # --- Scratch space
 
 
@@ -925,19 +958,3 @@ def test_foobar(self):
     L = NS_a(U, v) * dx
     _ = derivative(L, U, du)
     # TODO: assert something
-
-
-def test_product_rule_conditional(self):
-    cell = triangle
-    P1 = FiniteElement("Lagrange", cell, 1, (), identity_pullback, H1)
-    domain = Mesh(FiniteElement("Lagrange", cell, 1, (2,), identity_pullback, H1))
-    V = FunctionSpace(domain, P1)
-    u = Coefficient(V)
-
-    k = conditional(u < 1, zero(), u)
-    F = (u * k).dx(0) * dx
-    a = derivative(F, u)
-
-    expr = apply_derivatives(apply_geometry_lowering(apply_algebra_lowering(a)))
-    assert not expr.empty()
-    # TODO: assert something better

--- a/test/test_derivative.py
+++ b/test/test_derivative.py
@@ -934,7 +934,7 @@ def test_product_rule_conditional(self):
     V = FunctionSpace(domain, P1)
     u = Coefficient(V)
 
-    k = conditional(u < 1, 0, u)
+    k = conditional(u < 1, zero(), u)
     F = (u * k).dx(0) * dx
     a = derivative(F, u)
 

--- a/test/test_derivative.py
+++ b/test/test_derivative.py
@@ -925,3 +925,19 @@ def test_foobar(self):
     L = NS_a(U, v) * dx
     _ = derivative(L, U, du)
     # TODO: assert something
+
+
+def test_product_rule_conditional(self):
+    cell = triangle
+    P1 = FiniteElement("Lagrange", cell, 1, (), identity_pullback, H1)
+    domain = Mesh(FiniteElement("Lagrange", cell, 1, (2,), identity_pullback, H1))
+    V = FunctionSpace(domain, P1)
+    u = Coefficient(V)
+
+    k = conditional(u < 1, 0, u)
+    F = (u * k).dx(0) * dx
+    a = derivative(F, u)
+
+    expr = apply_derivatives(apply_geometry_lowering(apply_algebra_lowering(a)))
+    assert not expr.empty()
+    # TODO: assert something better

--- a/ufl/algorithms/apply_derivatives.py
+++ b/ufl/algorithms/apply_derivatives.py
@@ -548,11 +548,15 @@ class GenericDerivativeRuleset(MultiFunction):
         if isinstance(dt, Zero) and isinstance(df, Zero):
             # Assuming dt and df have the same indices here, which
             # should be the case
-            return dt
+            return self.independent_operator(o)
         else:
             # Not placing t[1],f[1] outside, allowing arguments inside
             # conditionals.  This will make legacy ffc fail, but
             # should work with uflacs.
+            if isinstance(dt, Zero):
+                dt = self.independent_operator(o)
+            if isinstance(df, Zero):
+                df = self.independent_operator(o)
             c = o.ufl_operands[0]
             return conditional(c, dt, df)
 

--- a/ufl/algorithms/apply_derivatives.py
+++ b/ufl/algorithms/apply_derivatives.py
@@ -179,6 +179,9 @@ class GenericDerivativeRuleset(MultiFunction):
     # Constants are independent of any differentiation
     constant = independent_terminal
 
+    # Zero may have free indices
+    zero = independent_operator
+
     # Rules for form arguments must be specified in specialized rule set
     form_argument = override
 
@@ -548,15 +551,11 @@ class GenericDerivativeRuleset(MultiFunction):
         if isinstance(dt, Zero) and isinstance(df, Zero):
             # Assuming dt and df have the same indices here, which
             # should be the case
-            return self.independent_operator(o)
+            return dt
         else:
             # Not placing t[1],f[1] outside, allowing arguments inside
             # conditionals.  This will make legacy ffc fail, but
             # should work with uflacs.
-            if isinstance(dt, Zero):
-                dt = self.independent_operator(o)
-            if isinstance(df, Zero):
-                df = self.independent_operator(o)
             c = o.ufl_operands[0]
             return conditional(c, dt, df)
 

--- a/ufl/algorithms/remove_component_tensors.py
+++ b/ufl/algorithms/remove_component_tensors.py
@@ -14,6 +14,7 @@ from ufl.algorithms.map_integrands import map_integrand_dags
 from ufl.classes import ComponentTensor, Index, MultiIndex, Zero
 from ufl.corealg.map_dag import map_expr_dag
 from ufl.corealg.multifunction import MultiFunction
+from ufl.index_combination_utils import unique_sorted_indices
 
 
 class IndexReplacer(MultiFunction):
@@ -38,18 +39,19 @@ class IndexReplacer(MultiFunction):
             # Reuse if untouched
             return o
 
-        free_indices = []
-        index_dimensions = []
+        fi = []
         for i, d in zip(indices, o.ufl_index_dimensions):
             j = self.fimap.get(i, i)
             if isinstance(j, Index):
-                free_indices.append(j.count())
-                index_dimensions.append(d)
+                fi.append((j.count(), d))
+
+        fi = unique_sorted_indices(sorted(fi))
+        free_indices, index_dimensions = zip(*fi)
 
         return Zero(
             shape=o.ufl_shape,
-            free_indices=tuple(free_indices),
-            index_dimensions=tuple(index_dimensions),
+            free_indices=free_indices,
+            index_dimensions=index_dimensions,
         )
 
     def multi_index(self, o):

--- a/ufl/conditional.py
+++ b/ufl/conditional.py
@@ -13,7 +13,6 @@ from ufl.core.expr import ufl_err_str
 from ufl.core.operator import Operator
 from ufl.core.ufl_type import ufl_type
 from ufl.exprequals import expr_equals
-from ufl.indexed import Indexed
 from ufl.precedence import parstr
 
 # --- Condition classes ---

--- a/ufl/conditional.py
+++ b/ufl/conditional.py
@@ -292,7 +292,7 @@ class Conditional(Operator):
             raise ValueError("Shape mismatch between conditional branches.")
         tfi = true_value.ufl_free_indices
         ffi = false_value.ufl_free_indices
-        if tuple(sorted(tfi)) != tuple(sorted(ffi)):
+        if tfi != ffi:
             raise ValueError("Free index mismatch between conditional branches.")
         if isinstance(condition, (EQ, NE)):
             if not all(
@@ -306,10 +306,6 @@ class Conditional(Operator):
                 raise ValueError("Non-scalar == or != is not allowed.")
         Operator.__init__(self, (condition, true_value, false_value))
         self._initialised = True
-
-    def _simplify_indexed(self, multiindex):
-        (c, a, b) = self.ufl_operands
-        return Conditional(c, Indexed(a, multiindex), Indexed(b, multiindex))
 
     def evaluate(self, x, mapping, component, index_values):
         """Evaluate."""

--- a/ufl/conditional.py
+++ b/ufl/conditional.py
@@ -13,7 +13,6 @@ from ufl.core.expr import ufl_err_str
 from ufl.core.operator import Operator
 from ufl.core.ufl_type import ufl_type
 from ufl.exprequals import expr_equals
-from ufl.indexed import Indexed
 from ufl.precedence import parstr
 
 # --- Condition classes ---
@@ -284,7 +283,6 @@ class Conditional(Operator):
         # Checks
         if not isinstance(condition, Condition):
             raise ValueError("Expecting condition as first argument.")
-
         true_value = as_ufl(true_value)
         false_value = as_ufl(false_value)
         tsh = true_value.ufl_shape
@@ -307,10 +305,6 @@ class Conditional(Operator):
                 raise ValueError("Non-scalar == or != is not allowed.")
         Operator.__init__(self, (condition, true_value, false_value))
         self._initialised = True
-
-    def _simplify_indexed(self, multiindex):
-        (c, a, b) = self.ufl_operands
-        return Conditional(c, Indexed(a, multiindex), Indexed(b, multiindex))
 
     def evaluate(self, x, mapping, component, index_values):
         """Evaluate."""

--- a/ufl/conditional.py
+++ b/ufl/conditional.py
@@ -13,6 +13,7 @@ from ufl.core.expr import ufl_err_str
 from ufl.core.operator import Operator
 from ufl.core.ufl_type import ufl_type
 from ufl.exprequals import expr_equals
+from ufl.indexed import Indexed
 from ufl.precedence import parstr
 
 # --- Condition classes ---
@@ -283,6 +284,7 @@ class Conditional(Operator):
         # Checks
         if not isinstance(condition, Condition):
             raise ValueError("Expecting condition as first argument.")
+
         true_value = as_ufl(true_value)
         false_value = as_ufl(false_value)
         tsh = true_value.ufl_shape
@@ -305,6 +307,10 @@ class Conditional(Operator):
                 raise ValueError("Non-scalar == or != is not allowed.")
         Operator.__init__(self, (condition, true_value, false_value))
         self._initialised = True
+
+    def _simplify_indexed(self, multiindex):
+        (c, a, b) = self.ufl_operands
+        return Conditional(c, Indexed(a, multiindex), Indexed(b, multiindex))
 
     def evaluate(self, x, mapping, component, index_values):
         """Evaluate."""

--- a/ufl/exprequals.py
+++ b/ufl/exprequals.py
@@ -37,6 +37,9 @@ def expr_equals(self, other):
             # Delve into subtrees
             so = s.ufl_operands
             oo = o.ufl_operands
+            # Skip subtree if operands are the same
+            if so is oo:
+                continue
             if len(so) != len(oo):
                 return False
 

--- a/ufl/exprequals.py
+++ b/ufl/exprequals.py
@@ -20,7 +20,7 @@ def expr_equals(self, other):
         return False
 
     # Large objects are costly to compare with themselves
-    if self is other or self.ufl_operands is other.ufl_operands:
+    if (self is other) or (self.ufl_operands is other.ufl_operands):
         return True
 
     # Modelled after pre_traversal to avoid recursion:
@@ -37,9 +37,6 @@ def expr_equals(self, other):
             # Delve into subtrees
             so = s.ufl_operands
             oo = o.ufl_operands
-            # Skip subtrees if operands are the same
-            if so is oo:
-                continue
             if len(so) != len(oo):
                 return False
 
@@ -48,7 +45,7 @@ def expr_equals(self, other):
                 if s._ufl_typecode_ != o._ufl_typecode_:
                     return False
                 # Skip subtree if objects are the same
-                if s is o or s.ufl_operands is o.ufl_operands:
+                if s is o:
                     continue
                 if (id(s), id(o)) in equal_pairs:
                     continue

--- a/ufl/sorting.py
+++ b/ufl/sorting.py
@@ -143,6 +143,9 @@ def cmp_expr(a, b):
             # Delve into subtrees
             aops = a.ufl_operands
             bops = b.ufl_operands
+            # Skip subtree if operands are the same
+            if aops is bops:
+                continue
 
             # Sort by children in natural order
             for r, s in zip(aops, bops):

--- a/ufl/sorting.py
+++ b/ufl/sorting.py
@@ -143,9 +143,6 @@ def cmp_expr(a, b):
             # Delve into subtrees
             aops = a.ufl_operands
             bops = b.ufl_operands
-            # Skip subtrees if operands are the same
-            if aops is bops:
-                continue
 
             # Sort by children in natural order
             for r, s in zip(aops, bops):


### PR DESCRIPTION
Fixes https://github.com/FEniCS/dolfinx/issues/3698 by reverting changes introduced in https://github.com/FEniCS/ufl/pull/367, namely
- Fast exit logic in exprequals.py, presumably it was wrong because types were not compared.
- Simplification of Indexed Conditional, the issue has to do with derivatives creating Zero of the wrong shape, and this PR is an attempt to fix that.