### PR TITLE
Enforce tests are passing without warnings

### DIFF
--- a/.github/workflows/fenicsx-tests.yml
+++ b/.github/workflows/fenicsx-tests.yml
@@ -52,9 +52,9 @@ jobs:
           cd ffcx
           pip install .[ci]
       - name: Run FFCx unit tests
-        run: python3 -m pytest -n auto ffcx/test
+        run: python3 -m pytest -W error -n auto ffcx/test
       - name: Run FFCx demos
-        run: python3 -m pytest -n auto ffcx/demo/test_demos.py
+        run: python3 -m pytest -W error -n auto ffcx/demo/test_demos.py
 
   dolfinx-tests:
     name: Run DOLFINx tests

--- a/.github/workflows/fenicsx-tests.yml
+++ b/.github/workflows/fenicsx-tests.yml
@@ -52,9 +52,9 @@ jobs:
           cd ffcx
           pip install .[ci]
       - name: Run FFCx unit tests
-        run: python3 -m pytest -W error -n auto ffcx/test
+        run: python3 -m pytest -n auto ffcx/test
       - name: Run FFCx demos
-        run: python3 -m pytest -W error -n auto ffcx/demo/test_demos.py
+        run: python3 -m pytest -n auto ffcx/demo/test_demos.py
 
   dolfinx-tests:
     name: Run DOLFINx tests

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -41,8 +41,10 @@ jobs:
       - name: Lint with mypy
         run: mypy -p ufl
       - name: Run unit tests
+        # Run tests twice, coverage raises warnings, thus does not pass with -W error
         run: |
-          python -m pytest -W error -n auto --cov=ufl/ --junitxml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml test/
+          python -m pytest -W error -n auto test/
+          python -m pytest -n auto --cov=ufl/ --junitxml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml test/
       - name: Upload to Coveralls
         if: ${{ github.repository == 'FEniCS/ufl' && github.head_ref == '' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
         env:

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -42,7 +42,7 @@ jobs:
         run: mypy -p ufl
       - name: Run unit tests
         run: |
-          python -m pytest -W error -n auto --cov=ufl/ --junitxml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml test/
+          python -m pytest -n auto --cov=ufl/ --junitxml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml test/
       - name: Upload to Coveralls
         if: ${{ github.repository == 'FEniCS/ufl' && github.head_ref == '' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
         env:

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -42,7 +42,7 @@ jobs:
         run: mypy -p ufl
       - name: Run unit tests
         run: |
-          python -m pytest -n auto --cov=ufl/ --junitxml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml test/
+          python -m pytest -W error -n auto --cov=ufl/ --junitxml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml test/
       - name: Upload to Coveralls
         if: ${{ github.repository == 'FEniCS/ufl' && github.head_ref == '' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
         env:

--- a/ufl/algorithms/formtransformations.py
+++ b/ufl/algorithms/formtransformations.py
@@ -315,7 +315,6 @@ def compute_form_with_arity(form, arity, arguments=None):
         arguments = form.arguments()
 
     if len(arguments) < arity:
-        warnings.warn(f"Form has no parts with arity {arity}.")
         return 0 * form
 
     # Assuming that the form is not a sum of terms

--- a/ufl/algorithms/formtransformations.py
+++ b/ufl/algorithms/formtransformations.py
@@ -308,7 +308,11 @@ class PartExtracter(Transformer):
 
 
 def compute_form_with_arity(form, arity, arguments=None):
-    """Compute parts of form of given arity."""
+    """Compute parts of form of given arity.
+
+    Note:
+        If the form has no parts of the specified arity, this will return 0*form.
+    """
     # Extract all arguments in form
     if arguments is None:
         arguments = form.arguments()

--- a/ufl/algorithms/formtransformations.py
+++ b/ufl/algorithms/formtransformations.py
@@ -12,7 +12,6 @@
 # Modified by Jørgen S. Dokken, 2025.
 
 import logging
-import warnings
 
 from ufl.algebra import Conj
 from ufl.algorithms.formsplitter import extract_blocks


### PR DESCRIPTION
Will ensure future deprecations to be no longer used in tests.

The removed warning is a heads up to users. However is not a wrong usage of the functio, this should not result in an official warning - is documented now.

Fixes https://github.com/FEniCS/ufl/issues/204