### PR TITLE
Fix bug in operator derivative reconstruction

### DIFF
--- a/test/test_interpolate.py
+++ b/test/test_interpolate.py
@@ -192,3 +192,19 @@ def test_extract_base_form_operators(V1, V2):
     v = TestFunction(V1)
     F = Action(v * v2 * dx, Iv)
     assert extract_arguments(F) == [v, uhat]
+
+
+def test_operator_derivative_reconstruction(V1, V2):
+    u = Coefficient(V1)
+
+    # Define Interpolate
+    Iu = Interpolate(u, V2)
+
+    # -- Differentiate: Interpolate(u, V2) -- #
+    uhat = TrialFunction(V1)
+    dIu = derivative(Iu, u, uhat)
+    # Check operator derivative can be reconstructed
+    dIu_r = dIu._ufl_expr_reconstruct_(*dIu.ufl_operands)
+    dIu = expand_derivatives(dIu_r)
+
+    assert dIu == Interpolate(uhat, V2)

--- a/ufl/differentiation.py
+++ b/ufl/differentiation.py
@@ -165,7 +165,7 @@ class BaseFormOperatorDerivative(BaseFormDerivative, BaseFormOperator):
     def _ufl_expr_reconstruct_(
         self, *operands, function_space=None, derivatives=None, argument_slots=None
     ):
-        return Operator._ufl_expr_reconstruct_(*operands)
+        return Operator._ufl_expr_reconstruct_(self, *operands)
 
     # Set __repr__
     __repr__ = Operator.__repr__


### PR DESCRIPTION
Bug description:
 - Firedrake tests failed due to incorrect argument error.
 - Identified root cause as change to how `BaseFormOperatorDerivative` reconstruction is called.

Fix description:
 - Add `self` to the call of reconstruction operator to ensure correct arguments are passed.

Also added a rudimentary test to catch this specific case. 