### PR TITLE
Add return hatch for empty adjoint

### DIFF
--- a/test/test_duals.py
+++ b/test/test_duals.py
@@ -67,6 +67,18 @@ def test_mixed_functionspace(self):
     assert is_dual(V_mixed_dual)
 
 
+def test_empty_adjoint():
+    domain_2d = Mesh(LagrangeElement(triangle, 1, (2,)))
+    f_2d = LagrangeElement(triangle, 1)
+    V = FunctionSpace(domain_2d, f_2d)
+    u = Coefficient(V)
+    f = Coefficient(V)
+    J = inner(u, f) * dx
+    d2Jdu2 = derivative(derivative(J, u), u)
+    d2Jdu2_adj = adjoint(d2Jdu2)
+    assert d2Jdu2_adj.empty()
+
+
 def test_dual_coefficients():
     domain_2d = Mesh(LagrangeElement(triangle, 1, (2,)))
     f_2d = LagrangeElement(triangle, 1)

--- a/ufl/algorithms/formtransformations.py
+++ b/ufl/algorithms/formtransformations.py
@@ -497,7 +497,8 @@ def compute_form_adjoint(form, reordered_arguments=None):
     but keeping their elements and places in the integrand expressions.
     """
     arguments = form.arguments()
-
+    if form.empty():
+        return form
     parts = [arg.part() for arg in arguments]
     if set(parts) - {None}:
         J = extract_blocks(form, arity=2)


### PR DESCRIPTION
Often when applying derivatives to derive the first and second order adjoint equations, one require the adjoint of an operator that becomes empty/zero. This PR adds an early return for those cases.