### PR TITLE
Python 3.14 (dev) support

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14.0rc1']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14.0rc1']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14-dev']
 
     steps:
       - uses: actions/checkout@v4

--- a/test/test_strip_forms.py
+++ b/test/test_strip_forms.py
@@ -19,10 +19,6 @@ from ufl.algorithms import replace_terminal_data, strip_terminal_data
 from ufl.core.ufl_id import attach_ufl_id
 from ufl.core.ufl_type import UFLObject
 
-MIN_REF_COUNT = 2
-"""The minimum value returned by sys.getrefcount."""
-
-
 @attach_ufl_id
 class AugmentedMesh(Mesh, UFLObject):
     def __init__(self, *args, data):
@@ -49,6 +45,16 @@ class AugmentedConstant(Constant):
 
 
 def test_strip_form_arguments_strips_data_refs():
+    # The minimum value returned by sys.getrefcount.
+    # Python 3.14 introduced borrowing references https://docs.python.org/3.14/glossary.html#term-borrowed-reference.
+    # This changed the output of
+    #
+    #   a = object()
+    #   sys.getrefcount(a)
+    #
+    # from 2 to 1. Avoiding the additional temporary reference increase to pass a to getrefcount.
+    MIN_REF_COUNT = 1 if sys.version_info >= (3, 14) else 2
+
     mesh_data = object()
     fs_data = object()
     coeff_data = object()

--- a/test/test_strip_forms.py
+++ b/test/test_strip_forms.py
@@ -19,6 +19,7 @@ from ufl.algorithms import replace_terminal_data, strip_terminal_data
 from ufl.core.ufl_id import attach_ufl_id
 from ufl.core.ufl_type import UFLObject
 
+
 @attach_ufl_id
 class AugmentedMesh(Mesh, UFLObject):
     def __init__(self, *args, data):


### PR DESCRIPTION
Adds a Python 3.14 check to the CI, based on the current Python 3.14 release candidate.

Adapts test for new refcounting behaviour.

Fixes https://github.com/FEniCS/ufl/issues/397.