### PR TITLE
Update CI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # UFL - Unified Form Language
 
 [![UFL CI](https://github.com/FEniCS/ufl/actions/workflows/pythonapp.yml/badge.svg)](https://github.com/FEniCS/ufl/actions/workflows/pythonapp.yml)
-[![Coverage Status](https://coveralls.io/repos/github/FEniCS/ufl/badge.svg?branch=master)](https://coveralls.io/github/FEniCS/ufl?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/FEniCS/ufl/badge.svg?branch=main)](https://coveralls.io/github/FEniCS/ufl?branch=main)
 
 The Unified Form Language (UFL) is a domain specific language for
 declaration of finite element discretizations of variational forms. More

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # UFL - Unified Form Language
 
 [![UFL CI](https://github.com/FEniCS/ufl/actions/workflows/pythonapp.yml/badge.svg)](https://github.com/FEniCS/ufl/actions/workflows/pythonapp.yml)
+[![Spack build](https://github.com/FEniCS/ufl/actions/workflows/spack.yml/badge.svg)](https://github.com/FEniCS/ufl/actions/workflows/spack.yml)
 [![Coverage Status](https://coveralls.io/repos/github/FEniCS/ufl/badge.svg?branch=main)](https://coveralls.io/github/FEniCS/ufl?branch=main)
 
 The Unified Form Language (UFL) is a domain specific language for

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # UFL - Unified Form Language
 
-[![UFL CI](https://github.com/FEniCS/ufl/workflows/UFL%20CI/badge.svg)](https://github.com/FEniCS/ufl/workflows/UFL%20CI)
+[![UFL CI](https://github.com/FEniCS/ufl/actions/workflows/pythonapp.yml/badge.svg)](https://github.com/FEniCS/ufl/actions/workflows/pythonapp.yml)
 [![Coverage Status](https://coveralls.io/repos/github/FEniCS/ufl/badge.svg?branch=master)](https://coveralls.io/github/FEniCS/ufl?branch=master)
 
 The Unified Form Language (UFL) is a domain specific language for

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # UFL - Unified Form Language
 
+[![UFL CI](https://github.com/FEniCS/ufl/workflows/UFL%20CI/badge.svg)](https://github.com/FEniCS/ufl/workflows/UFL%20CI)
+[![Coverage Status](https://coveralls.io/repos/github/FEniCS/ufl/badge.svg?branch=master)](https://coveralls.io/github/FEniCS/ufl?branch=master)
+
 The Unified Form Language (UFL) is a domain specific language for
 declaration of finite element discretizations of variational forms. More
 precisely, it defines a flexible interface for choosing finite element
@@ -8,9 +11,6 @@ mathematical notation.
 
 UFL is part of the FEniCS Project. For more information, visit
 https://www.fenicsproject.org
-
-[![UFL CI](https://github.com/FEniCS/ufl/workflows/UFL%20CI/badge.svg)](https://github.com/FEniCS/ufl/workflows/UFL%20CI)
-[![Coverage Status](https://coveralls.io/repos/github/FEniCS/ufl/badge.svg?branch=master)](https://coveralls.io/github/FEniCS/ufl?branch=master)
 
 ## Documentation
 


### PR DESCRIPTION
CI badges were not correctly updating.

1) CI requires new GitHub syntax,
2) coverage used `master` as default branch, and
3) add new spack CI badge

Coveralls needs to be updated - CI correctly pushes results, but not incorporated correctly. Default branch needs to be changed?