### PR TITLE
Expose `ufl.Label`

### DIFF
--- a/ufl/__init__.py
+++ b/ufl/__init__.py
@@ -439,6 +439,7 @@ from ufl.tensors import (
     unit_vectors,
 )
 from ufl.utils.sequences import product
+from ufl.variable import Label
 
 __all__ = [
     "H1",
@@ -488,6 +489,7 @@ __all__ = [
     "Jacobian",
     "JacobianDeterminant",
     "JacobianInverse",
+    "Label",
     "Matrix",
     "MaxCellEdgeLength",
     "MaxFacetEdgeLength",


### PR DESCRIPTION
Currently unreachable as it is within `ufl.variable`, which is overloaded by the `variable` function at import