### PR TITLE
Introduce CellSequence

### DIFF
--- a/test/test_apply_coefficent_split.py
+++ b/test/test_apply_coefficent_split.py
@@ -29,7 +29,7 @@ def test_apply_coefficient_split(self):
     f0 = Coefficient(V0)
     f1 = Coefficient(V1)
     mesh = MeshSequence([mesh0, mesh1])
-    elem = MixedElement([elem0, elem1])
+    elem = MixedElement([elem0, elem1], make_cell_sequence=True)
     V = FunctionSpace(mesh, elem)
     f = Coefficient(V)
     coefficient_split = {f: (f0, f1)}

--- a/test/test_mixed_function_space_with_mesh_sequence.py
+++ b/test/test_mixed_function_space_with_mesh_sequence.py
@@ -13,13 +13,17 @@ from ufl import (
     SpatialCoordinate,
     TestFunction,
     TrialFunction,
+    derivative,
     div,
+    dot,
     grad,
     inner,
     split,
+    tetrahedron,
     triangle,
 )
 from ufl.algorithms import compute_form_data
+from ufl.cell import Cell, CellSequence
 from ufl.domain import extract_domains
 from ufl.pullback import contravariant_piola, identity_pullback
 from ufl.sobolevspace import H1, L2, HDiv
@@ -30,7 +34,7 @@ def test_mixed_function_space_with_mesh_sequence_cell():
     elem0 = LagrangeElement(cell, 1)
     elem1 = FiniteElement("Brezzi-Douglas-Marini", cell, 2, (2,), contravariant_piola, HDiv)
     elem2 = FiniteElement("Discontinuous Lagrange", cell, 1, (), identity_pullback, L2)
-    elem = MixedElement([elem0, elem1, elem2])
+    elem = MixedElement([elem0, elem1, elem2], make_cell_sequence=True)
     mesh0 = Mesh(LagrangeElement(cell, 1, (2,)), ufl_id=100)
     mesh1 = Mesh(LagrangeElement(cell, 1, (2,)), ufl_id=101)
     mesh2 = Mesh(LagrangeElement(cell, 1, (2,)), ufl_id=102)
@@ -88,7 +92,7 @@ def test_mixed_function_space_with_mesh_sequence_facet():
     elem0 = FiniteElement("Lagrange", cell, 1, (), identity_pullback, H1)
     elem1 = FiniteElement("Brezzi-Douglas-Marini", cell, 2, (2,), contravariant_piola, HDiv)
     elem2 = FiniteElement("Discontinuous Lagrange", cell, 1, (), identity_pullback, L2)
-    elem = MixedElement([elem0, elem1, elem2])
+    elem = MixedElement([elem0, elem1, elem2], make_cell_sequence=True)
     mesh0 = Mesh(FiniteElement("Lagrange", cell, 1, (2,), identity_pullback, H1), ufl_id=100)
     mesh1 = Mesh(FiniteElement("Lagrange", cell, 1, (2,), identity_pullback, H1), ufl_id=101)
     mesh2 = Mesh(FiniteElement("Lagrange", cell, 1, (2,), identity_pullback, H1), ufl_id=102)
@@ -179,7 +183,7 @@ def test_mixed_function_space_with_mesh_sequence_hash():
     elem0 = LagrangeElement(cell, 1)
     elem1 = FiniteElement("Brezzi-Douglas-Marini", cell, 1, (2,), contravariant_piola, HDiv)
     elem2 = FiniteElement("Discontinuous Lagrange", cell, 0, (), identity_pullback, L2)
-    elem = MixedElement([elem0, elem1, elem2])
+    elem = MixedElement([elem0, elem1, elem2], make_cell_sequence=True)
     mesh0 = Mesh(LagrangeElement(cell, 1, (2,)), ufl_id=100)
     mesh1 = Mesh(LagrangeElement(cell, 1, (2,)), ufl_id=101)
     mesh2 = Mesh(LagrangeElement(cell, 1, (2,)), ufl_id=102)
@@ -202,7 +206,7 @@ def test_mixed_function_space_with_mesh_sequence_raise():
     elem0 = FiniteElement("Lagrange", cell, 1, (), identity_pullback, H1)
     elem1 = FiniteElement("Brezzi-Douglas-Marini", cell, 1, (2,), contravariant_piola, HDiv)
     elem2 = FiniteElement("Discontinuous Lagrange", cell, 0, (), identity_pullback, L2)
-    elem = MixedElement([elem0, elem1, elem2])
+    elem = MixedElement([elem0, elem1, elem2], make_cell_sequence=True)
     mesh0 = Mesh(FiniteElement("Lagrange", cell, 1, (2,), identity_pullback, H1), ufl_id=100)
     mesh1 = Mesh(FiniteElement("Lagrange", cell, 1, (2,), identity_pullback, H1), ufl_id=101)
     mesh2 = Mesh(FiniteElement("Lagrange", cell, 1, (2,), identity_pullback, H1), ufl_id=102)
@@ -245,3 +249,106 @@ def test_mixed_function_space_with_mesh_sequence_raise():
             complex_mode=False,
         )
     assert e_info.match("Discontinuous type Coefficient must be restricted.")
+
+
+def test_mixed_function_space_with_mesh_sequence_quad_triangle():
+    dim = 2
+    coord_degree = 1
+    cell_q = Cell("quadrilateral")
+    cell_t = Cell("triangle")
+    mesh_q = Mesh(LagrangeElement(cell_q, coord_degree, (dim,)))
+    mesh_t = Mesh(LagrangeElement(cell_t, coord_degree, (dim,)))
+    mesh = MeshSequence([mesh_q, mesh_t])
+    assert mesh.ufl_cell() == CellSequence([cell_q, cell_t])
+    elem_q = LagrangeElement(cell_q, 1, ())  # Q1
+    elem_t = LagrangeElement(cell_t, 1, ())  # P1
+    elem = MixedElement([elem_q, elem_t], make_cell_sequence=True)
+    assert elem.cell == CellSequence([cell_q, cell_t])
+    dx_q = Measure("dx", mesh_q)
+    dx_t = Measure("dx", mesh_t)
+    ds_q = Measure(
+        "ds",
+        mesh_q,
+        intersect_measures=(Measure("ds", mesh_t),),
+    )
+    ds_t = Measure(
+        "ds",
+        mesh_t,
+        intersect_measures=(Measure("ds", mesh_q),),
+    )
+    V = FunctionSpace(mesh, elem)
+    u = Coefficient(V)
+    v = TestFunction(V)
+    u_q, u_t = split(u)
+    v_q, v_t = split(v)
+    n_q = FacetNormal(mesh_q)
+    n_t = FacetNormal(mesh_t)
+    C = 100.0
+    h = 0.1  # mesh size
+    interface_id = 999  # subdomain_id for the interface
+    F = (
+        inner(grad(u_q), grad(v_q)) * dx_q
+        + inner(grad(u_t), grad(v_t)) * dx_t
+        - inner((grad(u_q) + grad(u_t)) / 2, (v_q * n_q + v_t * n_t)) * ds_q(interface_id)
+        - inner((u_q * n_q + u_t * n_t), (grad(v_q) + grad(v_t)) / 2) * ds_t(interface_id)
+        + C / h * inner(u_q - u_t, v_q - v_t) * ds_q(interface_id)
+    )
+    _ = derivative(F, u)
+
+
+def test_mixed_function_space_with_mesh_sequence_tetrahedron_triangle():
+    mesh0 = Mesh(FiniteElement("Lagrange", tetrahedron, 1, (3,), identity_pullback, H1), ufl_id=100)
+    mesh1 = Mesh(FiniteElement("Lagrange", tetrahedron, 1, (3,), identity_pullback, H1), ufl_id=101)
+    mesh2 = Mesh(FiniteElement("Lagrange", triangle, 1, (3,), identity_pullback, H1), ufl_id=102)
+    mesh = MeshSequence([mesh0, mesh1, mesh2])
+    assert mesh.ufl_cell() == CellSequence([tetrahedron, tetrahedron, triangle])
+    elem0 = FiniteElement("Brezzi-Douglas-Marini", tetrahedron, 1, (3,), contravariant_piola, HDiv)
+    elem1 = FiniteElement("Discontinuous Lagrange", tetrahedron, 0, (), identity_pullback, L2)
+    elem2 = FiniteElement("Lagrange", triangle, 1, (), identity_pullback, H1)
+    elem = MixedElement([elem0, elem1, elem2], make_cell_sequence=True)
+    assert elem.cell == CellSequence([tetrahedron, tetrahedron, triangle])
+    V = FunctionSpace(mesh, elem)
+    V0 = FunctionSpace(mesh0, elem0)
+    V1 = FunctionSpace(mesh1, elem1)
+    u1 = TrialFunction(V1)
+    v0 = TestFunction(V0)
+    f = Coefficient(V, count=1000)
+    _f0, _f1, f2 = split(f)
+    n0 = FacetNormal(mesh0)
+    # Assemble (0, 1)-block.
+    dx2_ds0_dS1 = Measure(
+        "dx",
+        mesh2,
+        intersect_measures=(
+            Measure("ds", mesh0),
+            Measure("dS", mesh1),
+        ),
+    )
+    form = inner(grad(f2)[2] * u1("+"), dot(v0, n0)) * dx2_ds0_dS1(999)
+    fd = compute_form_data(
+        form,
+        do_apply_function_pullbacks=True,
+        do_apply_integral_scaling=True,
+        do_apply_geometry_lowering=True,
+        preserve_geometry_types=(CellVolume, FacetArea),
+        do_apply_restrictions=True,
+        do_estimate_degrees=True,
+        do_replace_functions=True,
+        coefficients_to_split=(f,),
+        complex_mode=False,
+    )
+    (id0,) = fd.integral_data
+    assert fd.preprocessed_form.arguments() == (v0, u1)
+    assert fd.reduced_coefficients == [
+        f,
+    ]
+    assert form.coefficients()[fd.original_coefficient_positions[0]] is f
+    assert id0.domain_integral_type_map[mesh0] == "exterior_facet"
+    assert id0.domain_integral_type_map[mesh1] == "interior_facet"
+    assert id0.domain_integral_type_map[mesh2] == "cell"
+    assert id0.domain is mesh2
+    assert id0.integral_type == "cell"
+    assert id0.subdomain_id == (999,)
+    assert fd.original_form.domain_numbering()[id0.domain] == 0
+    assert id0.integral_coefficients == set([f])
+    assert id0.enabled_coefficients == [True]

--- a/ufl/algorithms/apply_derivatives.py
+++ b/ufl/algorithms/apply_derivatives.py
@@ -863,8 +863,9 @@ class GradRuleset(GenericDerivativeRuleset):
                 else:
                     K = JacobianInverse(d)
                     rdim, gdim = K.ufl_shape
-                    if rdim != ref_dim:
-                        raise RuntimeError(f"{rdim} != {ref_dim}")
+                    if rdim > ref_dim:
+                        # Note that rdim < ref_dim if mixed-dimensional.
+                        raise RuntimeError(f"{rdim} > {ref_dim}")
                     if gdim != self._var_shape[0]:
                         raise RuntimeError(f"{gdim} != {self._var_shape[0]}")
                     # Note that rgrad[dofoffset + [0,ndof), [0,rdim)] are the components
@@ -921,8 +922,9 @@ class GradRuleset(GenericDerivativeRuleset):
                 assert ndof > 0
                 K = JacobianInverse(d)
                 rdim, gdim = K.ufl_shape
-                if rdim != ref_dim:
-                    raise RuntimeError(f"{rdim} != {ref_dim}")
+                if rdim > ref_dim:
+                    # Note that rdim < ref_dim if mixed-dimensional.
+                    raise RuntimeError(f"{rdim} > {ref_dim}")
                 if gdim != self._var_shape[0]:
                     raise RuntimeError(f"{gdim} != {self._var_shape[0]}")
                 # Note that rgrad[dofoffset + [0,ndof), [0,rdim), [0,rdim)] are the components

--- a/ufl/algorithms/compute_form_data.py
+++ b/ufl/algorithms/compute_form_data.py
@@ -39,7 +39,7 @@ from ufl.algorithms.replace import replace
 from ufl.classes import Coefficient, Form, FunctionSpace, GeometricFacetQuantity
 from ufl.constantvalue import Zero
 from ufl.corealg.traversal import traverse_unique_terminals
-from ufl.domain import extract_domains, extract_unique_domain
+from ufl.domain import MeshSequence, extract_domains, extract_unique_domain
 from ufl.utils.sequences import max_degree
 
 
@@ -150,15 +150,21 @@ def _check_facet_geometry(integral_data):
     """Check facet geometry."""
     for itg_data in integral_data:
         for itg in itg_data.integrals:
-            it = itg_data.integral_type
-            # Facet geometry is only valid in facet integrals.
-            # Allowing custom integrals to pass as well, although
-            # that's not really strict enough.
-            if not ("facet" in it or "custom" in it or "interface" in it):
-                # Not a facet integral
-                for expr in traverse_unique_terminals(itg.integrand()):
-                    cls = expr._ufl_class_
-                    if issubclass(cls, GeometricFacetQuantity):
+            for expr in traverse_unique_terminals(itg.integrand()):
+                cls = expr._ufl_class_
+                if issubclass(cls, GeometricFacetQuantity):
+                    domain = extract_unique_domain(expr, expand_mesh_sequence=False)
+                    if isinstance(domain, MeshSequence):
+                        raise RuntimeError(
+                            f"Not expecting a terminal object on a "
+                            f"mesh sequence at this stage: found {expr!r}"
+                        )
+                    it = itg_data.domain_integral_type_map[domain]
+                    # Facet geometry is only valid in facet integrals.
+                    # Allowing custom integrals to pass as well, although
+                    # that's not really strict enough.
+                    if not ("facet" in it or "custom" in it or "interface" in it):
+                        # Not a facet integral
                         raise ValueError(f"Integral of type {it} cannot contain a {cls.__name__}.")
 
 

--- a/ufl/algorithms/estimate_degrees.py
+++ b/ufl/algorithms/estimate_degrees.py
@@ -98,9 +98,11 @@ class SumDegreeEstimator(MultiFunction):
         This is used when derivatives are taken. It does not reduce the degree when
         TensorProduct elements or quadrilateral elements are involved.
         """
-        # Can have multiple domains of the same cell type.
-        (cell,) = set(d.ufl_cell() for d in extract_domains(v))
-        if isinstance(f, int) and cell.cellname not in ["quadrilateral", "hexahedron"]:
+        # Can have multiple domains e.g. in mixed cell type problems.
+        cells = set(d.ufl_cell() for d in extract_domains(v))
+        if isinstance(f, int) and all(
+            cell.cellname not in ["quadrilateral", "hexahedron"] for cell in cells
+        ):
             return max(f - 1, 0)
         else:
             return f

--- a/ufl/domain.py
+++ b/ufl/domain.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from ufl.core.expr import Expr
     from ufl.finiteelement import AbstractFiniteElement  # To avoid cyclic import when type-hinting.
     from ufl.form import Form
-from ufl.cell import AbstractCell
+from ufl.cell import AbstractCell, CellSequence
 from ufl.core.ufl_id import attach_ufl_id
 from ufl.core.ufl_type import UFLObject
 from ufl.corealg.traversal import traverse_unique_terminals
@@ -217,17 +217,14 @@ class MeshSequence(AbstractDomain, UFLObject):
         if any(isinstance(m, MeshSequence) for m in meshes):
             raise NotImplementedError("""
                 Currently component meshes can not include MeshSequence instances""")
-        # currently only support single cell type.
-        (self._ufl_cell,) = set(m.ufl_cell() for m in meshes)
+        self._ufl_cell = CellSequence(tuple(m.ufl_cell() for m in meshes))
         (gdim,) = set(m.geometric_dimension for m in meshes)
-        # TODO: Need to change for more general mixed meshes.
-        (tdim,) = set(m.topological_dimension for m in meshes)
+        tdim = self._ufl_cell.topological_dimension
         AbstractDomain.__init__(self, tdim, gdim)
         self._meshes = tuple(meshes)
 
     def ufl_cell(self):
         """Get the cell."""
-        # TODO: Might need MixedCell class for more general mixed meshes.
         return self._ufl_cell
 
     def __repr__(self):

--- a/ufl/finiteelement.py
+++ b/ufl/finiteelement.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import abc as _abc
 from collections.abc import Sequence
 
-from ufl.cell import Cell as _Cell
+from ufl.cell import AbstractCell
 from ufl.pullback import AbstractPullback as _AbstractPullback
 from ufl.sobolevspace import SobolevSpace as _SobolevSpace
 from ufl.utils.sequences import product
@@ -94,7 +94,7 @@ class AbstractFiniteElement(_abc.ABC):
         """
 
     @_abc.abstractproperty
-    def cell(self) -> _Cell:
+    def cell(self) -> AbstractCell:
         """Return the cell of the finite element."""
 
     @_abc.abstractproperty


### PR DESCRIPTION
- Extend `MeshSequence`  multi-domain formulation to allow for multiple types of cells of potentially different topological dimensions.
- Introduce `CellSequence`, which gives the cell type of a `MeshSequence`.

This is a thin layer on top of the single-cell-type `MeshSequence` formulation.

@jorgensd @mscroggs @jpdean @jhale 