### PR TITLE
Try splitting python-app workflow into separable steps

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -12,7 +12,6 @@ on:
       - main
 
 jobs:
-
   lint-code:
     uses: ./.github/workflows/linting.yml
 
@@ -21,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     uses: ./.github/workflows/pythonapp.yml
     with:
@@ -29,7 +28,7 @@ jobs:
       os: ${{ matrix.os }}
       deploy: ${{ github.repository == 'FEniCS/ufl' && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') ) && matrix.os == 'ubuntu-latest' && matrix.python-version == 3.12 }}
 
-  build-docs:  
+  build-docs:
     needs: [lint-code, run-tests]
     uses: ./.github/workflows/docs.yml
     with:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -64,7 +64,7 @@ jobs:
       url: https://test.pypi.org/p/fenics-ufl
     permissions:
       id-token: write
-    
+
     steps:
       - uses: actions/download-artifact@v5
         with:
@@ -75,7 +75,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
-  
+
   upload_pypi:
     name: Upload to PyPI (optional)
     if: ${{ github.event.inputs.pypi_publish == 'true' }}
@@ -86,7 +86,7 @@ jobs:
       url: https://pypi.org/p/fenics-ufl
     permissions:
       id-token: write
-    
+
     steps:
       - uses: actions/download-artifact@v5
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,33 +2,32 @@ name: Build UFL Documentation
 on:
   workflow_call:
     inputs:
-        deploy:
-            description: 'Deploy documentation'
-            required: false
-            default: false
-            type: boolean
+      deploy:
+        description: "Deploy documentation"
+        required: false
+        default: false
+        type: boolean
 
   workflow_dispatch:
     inputs:
-        deploy:
-            description: 'Deploy documentation'
-            required: false
-            default: false
-            type: boolean
+      deploy:
+        description: "Deploy documentation"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-
       - uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: 3.12
-  
+
       - name: Install UFL
         run: python -m pip install .[docs]
 
@@ -46,32 +45,32 @@ jobs:
           if-no-files-found: error
 
       - name: Checkout FEniCS/docs
-        if: ${{ inputs.deploy == true }}  
+        if: ${{ inputs.deploy == true }}
         uses: actions/checkout@v5
         with:
-            repository: "FEniCS/docs"
-            path: "docs"
-            ssh-key: "${{ secrets.SSH_GITHUB_DOCS_PRIVATE_KEY }}"
-        
+          repository: "FEniCS/docs"
+          path: "docs"
+          ssh-key: "${{ secrets.SSH_GITHUB_DOCS_PRIVATE_KEY }}"
+
       - name: Set version name
-        if: ${{ inputs.deploy == true }} 
+        if: ${{ inputs.deploy == true }}
         run: |
-              echo "VERSION_NAME=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-        
+          echo "VERSION_NAME=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
       - name: Copy documentation into repository
-        if: ${{ inputs.deploy == true }}          
+        if: ${{ inputs.deploy == true }}
         run: |
-            cd docs
-            git rm -r --ignore-unmatch ufl/${{ env.VERSION_NAME }}
-            mkdir -p ufl/${{ env.VERSION_NAME }}
-            cp -r ../doc/build/html/* ufl/${{ env.VERSION_NAME }}
-    
+          cd docs
+          git rm -r --ignore-unmatch ufl/${{ env.VERSION_NAME }}
+          mkdir -p ufl/${{ env.VERSION_NAME }}
+          cp -r ../doc/build/html/* ufl/${{ env.VERSION_NAME }}
+
       - name: Commit and push documentation to FEniCS/docs
-        if: ${{ inputs.deploy == true }}            
+        if: ${{ inputs.deploy == true }}
         run: |
-              cd docs
-              git config --global user.email "fenics@github.com"
-              git config --global user.name "FEniCS GitHub Actions"
-              git add --all
-              git commit --allow-empty -m "Python FEniCS/ufl@${{ github.sha }}"
-              git push
+          cd docs
+          git config --global user.email "fenics@github.com"
+          git config --global user.name "FEniCS GitHub Actions"
+          git add --all
+          git commit --allow-empty -m "Python FEniCS/ufl@${{ github.sha }}"
+          git push

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,4 +1,3 @@
-
 name: Run linters on UFL
 on:
   workflow_call:
@@ -8,20 +7,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-
       - uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: 3.12
-  
+
       - name: Lint with ruff
         run: |
           pip install ruff
           ruff check .
           ruff format --check .
-  
+
       - name: Install UFL
         run: python -m pip install .[ci]
 

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -5,43 +5,42 @@ name: UFL CI
 on:
   workflow_call:
     inputs:
-        python-version:
-          required: false
-          default: '3.12'
-          type: string
-        os:
-          required: false
-          default: 'ubuntu-latest'
-          type: string
-        deploy:
-            description: 'Deploy documentation'
-            required: false
-            default: false
-            type: boolean
+      python-version:
+        required: false
+        default: "3.12"
+        type: string
+      os:
+        required: false
+        default: "ubuntu-latest"
+        type: string
+      deploy:
+        description: "Deploy documentation"
+        required: false
+        default: false
+        type: boolean
 
   workflow_dispatch:
     inputs:
-        python-version:
-          description: 'Python version'
-          required: false
-          default: '3.12'
-          type: string
-        os:
-          description: 'Operating system'
-          required: false
-          default: 'ubuntu-latest'
-          type: string
-        deploy:
-            description: 'Deploy documentation'
-            required: false
-            default: false
-            type: boolean
+      python-version:
+        description: "Python version"
+        required: false
+        default: "3.12"
+        type: string
+      os:
+        description: "Operating system"
+        required: false
+        default: "ubuntu-latest"
+        type: string
+      deploy:
+        description: "Deploy documentation"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   build:
     runs-on: ${{ inputs.os }}
     steps:
-
       - uses: actions/checkout@v5
 
       - name: Set up Python
@@ -74,5 +73,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run:
-          coveralls
+        run: coveralls


### PR DESCRIPTION
The monolithic `pythonapp.yml` is broken into separable steps, which are all called from `deploy.yml`, making it easier to pinpoint issues, and run manual triggers.

Logic is now:

1. Lint code
2. If 1 is successful run test matrix on python and os version
   2b) if successful, upload coveralls if on main or on a tag.
3. If 2 is successful build and upload documentation.
