### PR TITLE
Change to dev-main firedrake container for TSFC testing

### DIFF
--- a/.github/workflows/tsfc-tests.yml
+++ b/.github/workflows/tsfc-tests.yml
@@ -11,7 +11,7 @@ jobs:
     name: Run TSFC tests
     runs-on: ubuntu-latest
     container:
-      image: firedrakeproject/firedrake-vanilla-default:latest
+      image: firedrakeproject/firedrake-vanilla-default:dev-main
     steps:
       - name: Uninstall existing UFL
         run: |


### PR DESCRIPTION
Test against `main`, not `release`.

Fixes `TSFC` CI, after interface change in https://github.com/FEniCS/ufl/pull/385.