### PR TITLE
replace: only expand CoefficientDerivative

### DIFF
--- a/test/test_algorithms.py
+++ b/test/test_algorithms.py
@@ -5,7 +5,7 @@ __date__ = "2008-03-12 -- 2009-01-28"
 # Modified by Garth N. Wells, 2009
 
 import pytest
-from utils import ForeignDerivative, LagrangeElement
+from utils import ForeignDerivative, LagrangeElement, MixedElement
 
 from ufl import (
     Argument,
@@ -25,6 +25,7 @@ from ufl import (
     grad,
     inner,
     sin,
+    split,
     triangle,
 )
 from ufl.algorithms import (
@@ -207,10 +208,35 @@ def test_replace_foreign_derivative(domain, space):
     """
     f = Coefficient(space)
     g = Coefficient(space)
+    test = TestFunction(space)
+
+    # replace Expr with ForeignDerivative
     expr = derivative(f.dx(0) * f, f) + ForeignDerivative(f.dx(0))
     result = replace(expr, {f: g})
-
-    test = TestFunction(space)
     expected = test.dx(0) * g + g.dx(0) * test + ForeignDerivative(g.dx(0))
+    assert result == expected
 
+    # replace Form with ForeignDerivative
+    Df = ForeignDerivative(f)
+    form =  derivative(inner(f.dx(0), f.dx(0))*dx, f) + inner(Df, test)*dx
+    result = replace(form, {f: g})
+
+    Dg = ForeignDerivative(g)
+    expected = (inner(g.dx(0), test.dx(0)) + inner(test.dx(0), g.dx(0)))*dx +  inner(Dg, test)*dx
+    assert result == expected
+
+
+def test_replace_mixed_element(domain, element):
+    element = MixedElement([element, element])
+    space = FunctionSpace(domain, element)
+    z = Coefficient(space)
+    w = Coefficient(space)
+
+    u, p = split(z)
+    form =  derivative((inner(grad(u), grad(u)) + inner(p, p))*dx, z)
+    result = replace(form, {z: w})
+
+    u, p = split(w)
+    expected = derivative((inner(grad(u), grad(u)) + inner(p, p))*dx, w)
+    expected = expand_derivatives(expected)
     assert result == expected

--- a/test/test_algorithms.py
+++ b/test/test_algorithms.py
@@ -5,7 +5,7 @@ __date__ = "2008-03-12 -- 2009-01-28"
 # Modified by Garth N. Wells, 2009
 
 import pytest
-from utils import LagrangeElement
+from utils import ForeignDerivative, LagrangeElement
 
 from ufl import (
     Argument,
@@ -17,6 +17,7 @@ from ufl import (
     TestFunction,
     TrialFunction,
     adjoint,
+    derivative,
     div,
     dot,
     ds,
@@ -34,7 +35,10 @@ from ufl.algorithms import (
     extract_coefficients,
     extract_elements,
     extract_unique_elements,
+    replace,
 )
+from ufl.algorithms.analysis import has_exact_type
+from ufl.classes import ComponentTensor
 from ufl.corealg.traversal import (
     post_traversal,
     pre_traversal,
@@ -194,4 +198,19 @@ def test_remove_component_tensors(domain):
 
     fd = compute_form_data(form, do_remove_component_tensors=True)
 
-    assert "ComponentTensor" not in repr(fd.preprocessed_form)
+    assert not has_exact_type(fd.preprocessed_form, ComponentTensor)
+
+
+def test_replace_foreign_derivative(domain, space):
+    """Test that replace only expands CoeffientDerivative and does not break
+    with foreign derivatives (e.g. irksome.TimeDerivative).
+    """
+    f = Coefficient(space)
+    g = Coefficient(space)
+    expr = derivative(f.dx(0) * f, f) + ForeignDerivative(f.dx(0))
+    result = replace(expr, {f: g})
+
+    test = TestFunction(space)
+    expected = test.dx(0) * g + g.dx(0) * test + ForeignDerivative(g.dx(0))
+
+    assert result == expected

--- a/test/test_algorithms.py
+++ b/test/test_algorithms.py
@@ -218,11 +218,11 @@ def test_replace_foreign_derivative(domain, space):
 
     # replace Form with ForeignDerivative
     Df = ForeignDerivative(f)
-    form =  derivative(inner(f.dx(0), f.dx(0))*dx, f) + inner(Df, test)*dx
+    form = derivative(inner(f.dx(0), f.dx(0)) * dx, f) + inner(Df, test) * dx
     result = replace(form, {f: g})
 
     Dg = ForeignDerivative(g)
-    expected = (inner(g.dx(0), test.dx(0)) + inner(test.dx(0), g.dx(0)))*dx +  inner(Dg, test)*dx
+    expected = (inner(g.dx(0), test.dx(0)) + inner(test.dx(0), g.dx(0))) * dx + inner(Dg, test) * dx
     assert result == expected
 
 
@@ -233,10 +233,13 @@ def test_replace_mixed_element(domain, element):
     w = Coefficient(space)
 
     u, p = split(z)
-    form =  derivative((inner(grad(u), grad(u)) + inner(p, p))*dx, z)
+    form = derivative((inner(grad(u), grad(u)) + inner(p, p)) * dx, z)
     result = replace(form, {z: w})
 
     u, p = split(w)
-    expected = derivative((inner(grad(u), grad(u)) + inner(p, p))*dx, w)
+    expected = derivative((inner(grad(u), grad(u)) + inner(p, p)) * dx, w)
     expected = expand_derivatives(expected)
-    assert result == expected
+    # result and expected are built independently, so their dummy
+    # summation indices may be numbered differently; compare signatures
+    # rather than raw equality.
+    assert result.signature() == expected.signature()

--- a/test/test_automatic_differentiation.py
+++ b/test/test_automatic_differentiation.py
@@ -12,7 +12,7 @@ Other tests check for mathematical correctness of diff and derivative.
 """
 
 import pytest
-from utils import FiniteElement, LagrangeElement
+from utils import FiniteElement, ForeignDerivative, LagrangeElement
 
 from ufl import (
     And,
@@ -38,6 +38,7 @@ from ufl import (
     Or,
     PermutationSymbol,
     SpatialCoordinate,
+    TestFunction,
     acos,
     as_matrix,
     as_tensor,
@@ -84,7 +85,7 @@ from ufl import (
     triangle,
     variable,
 )
-from ufl.algorithms import expand_derivatives
+from ufl.algorithms import expand_coefficient_derivatives, expand_derivatives
 from ufl.algorithms.apply_algebra_lowering import apply_algebra_lowering
 from ufl.algorithms.apply_derivatives import apply_derivatives
 from ufl.algorithms.apply_geometry_lowering import apply_geometry_lowering
@@ -714,3 +715,63 @@ def test_diff_grad_grad_jacobian(cell, gdim, order, lower_alg, lower_geo, apply_
 
     assert δF_u == 0
     assert δF_u.ufl_shape == (gdim, tdim, gdim, gdim)
+
+
+def test_coefficient_derivative_grad_coeff(self, d_expr):
+    """Test that CoefficientDerivative expansion"""
+    _d, collection = d_expr
+
+    u = collection.shared_objects.u
+    v = collection.shared_objects.v
+    w = collection.shared_objects.w
+    for f in (u, v, w):
+        test = TestFunction(f.ufl_function_space())
+
+        expected = grad(test)
+        before = derivative(grad(f), f)
+        after = expand_coefficient_derivatives(before)
+        self.assertEqualTotalShape(before, after)
+        assert after == expected
+
+        expected = grad(grad(test))
+        before = derivative(grad(grad(f)), f)
+        after = expand_coefficient_derivatives(before)
+        self.assertEqualTotalShape(before, after)
+        assert after == expected
+
+        expected = grad(grad(grad(test)))
+        before = derivative(grad(grad(grad(f))), f)
+        after = expand_coefficient_derivatives(before)
+        self.assertEqualTotalShape(before, after)
+        assert after == expected
+
+
+def test_coefficient_derivative_grad_coordinate(self):
+    """Test that CoordinateDerivative objects do not get expanded"""
+    cell = triangle
+    gdim = cell.topological_dimension
+    geometry_degree = 1
+    domain = Mesh(LagrangeElement(cell, geometry_degree, (gdim,)))
+    x = SpatialCoordinate(domain)
+
+    expected = grad(x)
+    before = grad(x)
+    after = expand_coefficient_derivatives(before)
+    self.assertEqualTotalShape(before, after)
+    assert after == expected
+
+
+def test_coefficient_derivative_foreign_derivative(self):
+    """Test that foreign Derivative objects do not get expanded"""
+    cell = triangle
+    gdim = cell.topological_dimension
+    geometry_degree = 1
+    domain = Mesh(LagrangeElement(cell, geometry_degree, (gdim,)))
+
+    x = SpatialCoordinate(domain)
+
+    expected = ForeignDerivative(x)
+    before = ForeignDerivative(x)
+    after = expand_coefficient_derivatives(before)
+    self.assertEqualTotalShape(before, after)
+    assert after == expected

--- a/test/test_classcoverage.py
+++ b/test/test_classcoverage.py
@@ -116,8 +116,8 @@ from ufl.classes import (
     all_ufl_classes,
 )
 
-has_repr = set()
-has_dict = set()
+has_repr: set[str] = set()
+has_dict: set[str] = set()
 
 
 def _test_object(a, shape, free_indices):

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,6 +1,8 @@
 """UFL test utils."""
 
 from ufl.cell import AbstractCell, Cell, CellSequence
+from ufl.classes import Derivative
+from ufl.core.ufl_type import ufl_type
 from ufl.finiteelement import AbstractFiniteElement
 from ufl.pullback import (
     AbstractPullback,
@@ -249,3 +251,19 @@ class MixedElement(FiniteElement):
             _repr=f"utils.MixedElement({sub_elements!r})",
             _str=f"<MixedElement with {len(sub_elements)} sub-element(s)>",
         )
+
+
+@ufl_type(num_ops=1, inherit_shape_from_operand=0, inherit_indices_from_operand=0)
+class ForeignDerivative(Derivative):
+    """Mock class for irksome.TimeDerivative"""
+
+    __slots__ = ()
+
+    def __new__(cls, f):
+        return Derivative.__new__(cls)
+
+    def __init__(self, f):
+        Derivative.__init__(self, (f,))
+
+    def __str__(self):
+        return f"d{{{self.ufl_operands[0]}}}/dt"

--- a/ufl/algorithms/__init__.py
+++ b/ufl/algorithms/__init__.py
@@ -31,6 +31,7 @@ __all__ = [
     "compute_form_rhs",
     "compute_form_signature",
     "estimate_total_polynomial_degree",
+    "expand_coefficient_derivatives",
     "expand_derivatives",
     "expand_indices",
     "extract_arguments",
@@ -54,7 +55,7 @@ __all__ = [
     "validate_form",
 ]
 
-from ufl.algorithms.ad import expand_derivatives
+from ufl.algorithms.ad import expand_coefficient_derivatives, expand_derivatives
 from ufl.algorithms.analysis import (
     extract_arguments,
     extract_base_form_operators,

--- a/ufl/algorithms/ad.py
+++ b/ufl/algorithms/ad.py
@@ -11,10 +11,11 @@
 import warnings
 
 from ufl.algorithms.apply_algebra_lowering import apply_algebra_lowering
-from ufl.algorithms.apply_derivatives import apply_derivatives
+from ufl.algorithms.apply_derivatives import apply_coefficient_derivatives, apply_derivatives
+from ufl.classes import BaseForm, Expr
 
 
-def expand_derivatives(form, **kwargs):
+def expand_derivatives(expr: Expr | BaseForm, **kwargs):
     """Expand all derivatives of expr.
 
     In the returned expression g which is mathematically
@@ -28,9 +29,25 @@ def expand_derivatives(form, **kwargs):
         warnings("Deprecation: expand_derivatives no longer takes any keyword arguments")
 
     # Lower abstractions for tensor-algebra types into index notation
-    form = apply_algebra_lowering(form)
+    expr = apply_algebra_lowering(expr)
 
     # Apply differentiation
-    form = apply_derivatives(form)
+    expr = apply_derivatives(expr)
 
-    return form
+    return expr
+
+
+def expand_coefficient_derivatives(expr: Expr | BaseForm):
+    """Expand only CoefficientDerivative objects within expr.
+
+    In the returned expression, which is mathematically
+    equivalent to expr, there are no CoefficientDerivative
+    objects left.
+    """
+    # Lower abstractions for tensor-algebra types into index notation
+    expr = apply_algebra_lowering(expr)
+
+    # Apply differentiation
+    expr = apply_coefficient_derivatives(expr)
+
+    return expr

--- a/ufl/algorithms/ad.py
+++ b/ufl/algorithms/ad.py
@@ -18,7 +18,7 @@ from ufl.classes import BaseForm, Expr
 def expand_derivatives(expr: Expr | BaseForm, **kwargs):
     """Expand all derivatives of expr.
 
-    In the returned expression g which is mathematically
+    In the returned expression, which is mathematically
     equivalent to expr, there are no VariableDerivative
     or CoefficientDerivative objects left, and Grad
     objects have been propagated to Terminal nodes.

--- a/ufl/algorithms/ad.py
+++ b/ufl/algorithms/ad.py
@@ -26,7 +26,7 @@ def expand_derivatives(expr: Expr | BaseForm, **kwargs):
     # For a deprecation period (I see that dolfin-adjoint passes some
     # args here)
     if kwargs:
-        warnings("Deprecation: expand_derivatives no longer takes any keyword arguments")
+        warnings.warn("Deprecation: expand_derivatives no longer takes any keyword arguments")
 
     # Lower abstractions for tensor-algebra types into index notation
     expr = apply_algebra_lowering(expr)

--- a/ufl/algorithms/apply_derivatives.py
+++ b/ufl/algorithms/apply_derivatives.py
@@ -1986,18 +1986,21 @@ class BaseFormOperatorDerivativeRecorder:
         return self
 
 
-def apply_derivatives(expression):
+def apply_derivatives(expression, dag_traverser=None):
     """Apply derivatives to an expression.
 
     Args:
         expression: A Form, an Expr or a BaseFormOperator to be differentiated
 
+        dag_traverser: An optional DerivativeRuleDispatcher or
+                       CoefficientDerivativeRuleDispatcher
+
     Returns:
         A differentiated expression
     """
     # Notation: Let `var` be the thing we are differentating with respect to.
-
-    dag_traverser = DerivativeRuleDispatcher()
+    if dag_traverser is None:
+        dag_traverser = DerivativeRuleDispatcher()
 
     # If we hit a base form operator (bfo), then if `var` is:
     #    - a BaseFormOperator → Return `d(expression)/dw` where `w` is
@@ -2294,25 +2297,8 @@ def apply_coordinate_derivatives(expression):
     return map_integrands(dag_traverser, expression)
 
 
-class CoefficientDerivativeRuleDispatcher(DAGTraverser):
+class CoefficientDerivativeRuleDispatcher(DerivativeRuleDispatcher):
     """Dispatcher."""
-
-    def __init__(
-        self,
-        compress: bool | None = True,
-        visited_cache: dict[tuple, Expr] | None = None,
-        result_cache: dict[Expr, Expr] | None = None,
-    ) -> None:
-        """Initialise."""
-        super().__init__(compress=compress, visited_cache=visited_cache, result_cache=result_cache)
-        # Record the operations delayed to the derivative expansion phase:
-        # Example: dN(u)/du where `N` is a BaseFormOperator and `u` a Coefficient
-        self.pending_operations = ()
-        # Create DAGTraverser caches.
-        self._dag_traverser_cache: dict[
-            tuple[type, Expr] | tuple[type, Expr, Expr, Expr] | tuple[type, Expr, Expr, Expr, Expr],
-            DAGTraverser,
-        ] = {}
 
     @singledispatchmethod
     def process(self, o: Expr) -> Expr:
@@ -2327,16 +2313,10 @@ class CoefficientDerivativeRuleDispatcher(DAGTraverser):
         """
         return super().process(o)
 
-    @process.register(Expr)
-    @process.register(BaseForm)  # type: ignore
-    def _(self, o: Expr | BaseForm) -> Expr | BaseForm:
-        """Apply to expr and base form."""
+    @process.register(Derivative)
+    def _(self, o: Derivative) -> Derivative:
+        """Apply to generic Derivative objects."""
         return self.reuse_if_untouched(o)
-
-    @process.register(Terminal)
-    def _(self, o: Terminal) -> Terminal:
-        """Apply to a terminal."""
-        return o
 
     @process.register(CoefficientDerivative)
     @DAGTraverser.postorder_only_children([0])
@@ -2358,24 +2338,8 @@ class CoefficientDerivativeRuleDispatcher(DAGTraverser):
         self.pending_operations += dag_traverser.pending_operations  # type: ignore
         return mapped_expr
 
-    @process.register(Indexed)
-    @DAGTraverser.postorder
-    def _(self, o: Indexed, Ap: Expr, ii: MultiIndex) -> Expr | BaseForm:
-        """Apply to an indexed."""
-        # Reuse if untouched
-        if Ap is o.ufl_operands[0]:
-            return o
-        r = len(Ap.ufl_shape) - len(ii)
-        if r:
-            kk = indices(r)
-            op = Indexed(Ap, MultiIndex(ii.indices() + kk))
-            op = as_tensor(op, kk)
-        else:
-            op = Indexed(Ap, ii)
-        return op
-
 
 def apply_coefficient_derivatives(expression):
     """Apply coefficient derivatives to an expression."""
     dag_traverser = CoefficientDerivativeRuleDispatcher()
-    return map_integrands(dag_traverser, expression)
+    return apply_derivatives(expression, dag_traverser=dag_traverser)

--- a/ufl/algorithms/apply_derivatives.py
+++ b/ufl/algorithms/apply_derivatives.py
@@ -2314,7 +2314,7 @@ class CoefficientDerivativeRuleDispatcher(DerivativeRuleDispatcher):
         return super().process(o)
 
     @process.register(Derivative)
-    def _(self, o: Derivative) -> Derivative:
+    def _(self, o: Expr) -> Expr:
         """Apply to generic Derivative objects."""
         return self.reuse_if_untouched(o)
 

--- a/ufl/algorithms/apply_derivatives.py
+++ b/ufl/algorithms/apply_derivatives.py
@@ -2315,17 +2315,28 @@ class CoefficientDerivativeRuleDispatcher(DerivativeRuleDispatcher):
 
     @process.register(Derivative)
     def _(self, o: Expr) -> Expr:
-        """Apply to generic Derivative objects."""
+        """Leave a foreign (non-UFL) Derivative subtype untouched."""
         return self.reuse_if_untouched(o)
 
-    @process.register(CoefficientDerivative)
-    @DAGTraverser.postorder_only_children([0])
-    def _(self, o: CoefficientDerivative, f: Expr | BaseForm) -> Expr | BaseForm:
-        """Apply to a coefficient_derivative."""
-        _, w, v, cd = o.ufl_operands
+    @process.register(CoefficientDerivative)  # type: ignore
+    def _(self, o: CoefficientDerivative) -> Expr | BaseForm:
+        """Apply to a coefficient_derivative.
+
+        Unlike the base DerivativeRuleDispatcher, this does not recurse
+        into the CoefficientDerivative's own content through ``self``:
+        that content is about to be Gateaux-differentiated, so it needs
+        the same full normalization (e.g. a spatial Grad pushed down to
+        a terminal) that GateauxDerivativeRuleset relies on under the
+        full pipeline, not the narrowed, CoefficientDerivative-only
+        treatment `self` gives to everything *outside* this node.
+        """
+        expr, w, v, cd = o.ufl_operands
+        full_dispatcher = self._dag_traverser_cache.setdefault(
+            (DerivativeRuleDispatcher,),  # type: ignore
+            DerivativeRuleDispatcher(),  # type: ignore
+        )
+        f = full_dispatcher(expr)  # type: ignore
         key = (GateauxDerivativeRuleset, w, v, cd)
-        # We need to go through the dag first to record the pending
-        # operations
         dag_traverser = self._dag_traverser_cache.setdefault(
             key,
             GateauxDerivativeRuleset(w, v, cd),  # type: ignore

--- a/ufl/algorithms/replace.py
+++ b/ufl/algorithms/replace.py
@@ -89,8 +89,10 @@ def replace(e, mapping):
     # is not attractive), or make replace lazy too.
     if has_exact_type(e, CoefficientDerivative):
         # Hack to avoid circular dependencies
-        from ufl.algorithms.ad import expand_derivatives
+        from ufl.algorithms.apply_algebra_lowering import apply_algebra_lowering
+        from ufl.algorithms.apply_derivatives import apply_coefficient_derivatives
 
-        e = expand_derivatives(e)
+        e = apply_algebra_lowering(e)
+        e = apply_coefficient_derivatives(e)
 
     return map_integrand_dags(Replacer(mapping2), e)

--- a/ufl/algorithms/replace.py
+++ b/ufl/algorithms/replace.py
@@ -89,10 +89,8 @@ def replace(e, mapping):
     # is not attractive), or make replace lazy too.
     if has_exact_type(e, CoefficientDerivative):
         # Hack to avoid circular dependencies
-        from ufl.algorithms.apply_algebra_lowering import apply_algebra_lowering
-        from ufl.algorithms.apply_derivatives import apply_coefficient_derivatives
+        from ufl.algorithms.ad import expand_coefficient_derivatives
 
-        e = apply_algebra_lowering(e)
-        e = apply_coefficient_derivatives(e)
+        e = expand_coefficient_derivatives(e)
 
     return map_integrand_dags(Replacer(mapping2), e)


### PR DESCRIPTION
`replace` was unecessarily expanding all derivatives too early.  This becomes a problem in Irksome where we introduce a `TimeDerivative` that cannot be expanded in UFL. 

This PR avoids this problem by expanding `CoefficientDerivative` only. 