### PR TITLE
CoefficientSplitter: fix again ReferenceGrad(Zero)

### DIFF
--- a/ufl/algorithms/apply_coefficient_split.py
+++ b/ufl/algorithms/apply_coefficient_split.py
@@ -215,14 +215,14 @@ class CoefficientSplitter(DAGTraverser):
         c = o
         if reference_value:
             c = ReferenceValue(c)
-        for _ in range(reference_grad):
+        for k in range(reference_grad):
             c = ReferenceGrad(c)
             if isinstance(c, Zero):
                 gdim = c.ufl_shape[-1]
                 c = Zero(
-                    o.ufl_shape + (gdim,) * reference_grad,
-                    o.ufl_free_indices,
-                    o.ufl_index_dimensions,
+                    c.ufl_shape + (gdim,) * (reference_grad - k - 1),
+                    c.ufl_free_indices,
+                    c.ufl_index_dimensions,
                 )
                 break
         if restricted == "+":


### PR DESCRIPTION
The first fix didn't take into account elements where the reference value shape differs from the physical value shape.