### PR TITLE
Add `arity` property to form

### DIFF
--- a/test/test_form.py
+++ b/test/test_form.py
@@ -38,6 +38,11 @@ def domain():
 
 
 @pytest.fixture
+def functional(domain):
+    return 1 * dx(domain)
+
+
+@pytest.fixture
 def mass(domain):
     cell = triangle
     element = LagrangeElement(cell, 1)
@@ -102,6 +107,14 @@ def test_form_arguments(mass, stiffness, convection, load):
     assert (v * dx + f * v * ds).arguments() == (v,)
     assert (u * v * dx(1) + v * u * dx(2)).arguments() == (v, u)
     assert ((f * v) * u * dx + (u * 3) * (v / 2) * dx(2)).arguments() == (v, u)
+
+
+def test_form_arity(functional, mass, stiffness, convection, load) -> None:
+    assert functional.arity == 0
+    assert mass.arity == 2
+    assert stiffness.arity == 2
+    assert convection.arity == 2
+    assert load.arity == 1
 
 
 def test_form_coefficients(element, domain):

--- a/test/test_form.py
+++ b/test/test_form.py
@@ -19,7 +19,6 @@ from ufl import (
     grad,
     inner,
     nabla_grad,
-    tetrahedron,
     triangle,
 )
 from ufl.argument import TestFunctions, TrialFunctions

--- a/test/test_form.py
+++ b/test/test_form.py
@@ -19,9 +19,12 @@ from ufl import (
     grad,
     inner,
     nabla_grad,
+    tetrahedron,
     triangle,
 )
+from ufl.argument import TestFunctions, TrialFunctions
 from ufl.form import BaseForm
+from ufl.functionspace import MixedFunctionSpace
 
 
 @pytest.fixture
@@ -121,6 +124,24 @@ def test_form_arity(functional, mass, stiffness, convection, load) -> None:
     assert (functional + stiffness).arity is None
     assert (load + mass).arity is None
     assert (load + stiffness).arity is None
+
+
+def test_form_arity_mixed(domain) -> None:
+    domain = Mesh(LagrangeElement(triangle, 1, (2,)))
+    V = FunctionSpace(domain, LagrangeElement(triangle, 1, (2,)))
+    W = FunctionSpace(domain, LagrangeElement(triangle, 1, (3,)))
+
+    U = MixedFunctionSpace(V, W)
+
+    v, sigma = TestFunctions(U)
+    u, tau = TrialFunctions(U)
+
+    linear = v[0] * dx + sigma[0] * dx
+    bilinear = v[0] * u[0] * dx + sigma[0] * tau[0] * dx
+
+    assert linear.arity == 1
+    assert bilinear.arity == 2
+    assert (linear + bilinear).arity is None
 
 
 def test_form_coefficients(element, domain):

--- a/test/test_form.py
+++ b/test/test_form.py
@@ -143,10 +143,21 @@ def test_form_arity_mixed(domain) -> None:
     assert bilinear.arity == 2
     assert (linear + bilinear).arity is None
 
-    linear_combined = (v[0] + sigma[0]) * dx
-    bilinear_combined = (v[0] * u[0] + sigma[0] * tau[0]) * dx
-    assert linear_combined.arity == 1
-    assert bilinear_combined.arity == 2
+    # combined mixed form integrals (unsupported)
+    with pytest.raises(
+        RuntimeError, match=r"Arity does not support mixed arguments in an integral."
+    ):
+        assert ((v[0] + sigma[0]) * dx).arity == 1
+
+    with pytest.raises(
+        RuntimeError, match=r"Arity does not support mixed arguments in an integral."
+    ):
+        assert ((v[0] * u[0] + sigma[0] * tau[0]) * dx).arity == 2
+
+    with pytest.raises(
+        RuntimeError, match=r"Arity does not support mixed arguments in an integral."
+    ):
+        assert ((v[0] + sigma[0] + v[0] * u[0] + sigma[0] * tau[0]) * dx).arity is None
 
 
 def test_form_coefficients(element, domain):

--- a/test/test_form.py
+++ b/test/test_form.py
@@ -143,6 +143,11 @@ def test_form_arity_mixed(domain) -> None:
     assert bilinear.arity == 2
     assert (linear + bilinear).arity is None
 
+    linear_combined = (v[0] + sigma[0]) * dx
+    bilinear_combined = (v[0] * u[0] + sigma[0] * tau[0]) * dx
+    assert linear_combined.arity == 1
+    assert bilinear_combined.arity == 2
+
 
 def test_form_coefficients(element, domain):
     space = FunctionSpace(domain, element)

--- a/test/test_form.py
+++ b/test/test_form.py
@@ -116,6 +116,12 @@ def test_form_arity(functional, mass, stiffness, convection, load) -> None:
     assert convection.arity == 2
     assert load.arity == 1
 
+    assert (functional + load).arity is None
+    assert (functional + mass).arity is None
+    assert (functional + stiffness).arity is None
+    assert (load + mass).arity is None
+    assert (load + stiffness).arity is None
+
 
 def test_form_coefficients(element, domain):
     space = FunctionSpace(domain, element)

--- a/ufl/form.py
+++ b/ufl/form.py
@@ -340,6 +340,11 @@ class Form(BaseForm):
         """Returns whether the form has no integrals."""
         return len(self.integrals()) == 0
 
+    @property
+    def arity(self):
+        """Arity of the form."""
+        return len(self.arguments())
+
     def ufl_domains(self):
         """Return the geometric integration domains occuring in the form.
 

--- a/ufl/form.py
+++ b/ufl/form.py
@@ -341,9 +341,28 @@ class Form(BaseForm):
         return len(self.integrals()) == 0
 
     @property
-    def arity(self):
-        """Arity of the form."""
-        return len(self.arguments())
+    def arity(self) -> int | None:
+        """Arity of the form.
+
+        Returns:
+            Number of arguments if all integrals share the argument count, otherwise None.
+        """
+        if not self._integrals:
+            return 0
+
+        from ufl.algorithms.analysis import extract_terminals_with_domain
+
+        arity = None
+        for integral in self._integrals:
+            args, _, _ = extract_terminals_with_domain(integral.integrand())
+            _arity = len(set(args))
+
+            if arity is None:
+                arity = _arity
+            elif arity != _arity:
+                return None
+
+        return arity
 
     def ufl_domains(self):
         """Return the geometric integration domains occuring in the form.

--- a/ufl/form.py
+++ b/ufl/form.py
@@ -353,11 +353,11 @@ class Form(BaseForm):
         if not self._integrals:
             return 0
 
-        from ufl.algorithms.analysis import extract_terminals_with_domain
+        from ufl.algorithms.analysis import extract_arguments
 
         arity = None
         for integral in self._integrals:
-            args, _, _ = extract_terminals_with_domain(integral.integrand())
+            args = extract_arguments(integral.integrand())
 
             if len(set(arg.part() for arg in args)) > 1:
                 raise RuntimeError("Arity does not support mixed arguments in an integral.")

--- a/ufl/form.py
+++ b/ufl/form.py
@@ -344,6 +344,9 @@ class Form(BaseForm):
     def arity(self) -> int | None:
         """Arity of the form.
 
+        Note:
+            Mixed function spaces are supported if the parts are not mixed in a single integral.
+
         Returns:
             Number of arguments if all integrals share the argument count, otherwise None.
         """
@@ -355,6 +358,10 @@ class Form(BaseForm):
         arity = None
         for integral in self._integrals:
             args, _, _ = extract_terminals_with_domain(integral.integrand())
+
+            if len(set(arg.part() for arg in args)) > 1:
+                raise RuntimeError("Arity does not support mixed arguments in an integral.")
+
             _arity = max((arg.number() + 1 for arg in args), default=0)
 
             if arity is None:

--- a/ufl/form.py
+++ b/ufl/form.py
@@ -355,7 +355,7 @@ class Form(BaseForm):
         arity = None
         for integral in self._integrals:
             args, _, _ = extract_terminals_with_domain(integral.integrand())
-            _arity = len(set(args))
+            _arity = max((arg.number() + 1 for arg in args), default=0)
 
             if arity is None:
                 arity = _arity


### PR DESCRIPTION
There is currently no better way than `len(form.arguments())` to check for the arity/rank of a form. Introduces property for simpler access. Since `rank` is already associated with tensor ranks in ufl, use the name `arity`.

If a form contains an ambiguous arity, i.e. terms with different argument counts `None` is returned.

Ref https://github.com/FEniCS/dolfinx/pull/4118.