### PR TITLE
Drop Python 3.10 support

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
         include:
           - os: windows-latest
             python-version: "3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ description = "Unified Form Language"
 readme = "README.md"
 license = "LGPL-3.0-or-later"
 license-files = ["COPYING*"]
-requires-python = ">=3.10.0"
+requires-python = ">=3.11"
 dependencies = ["numpy"]
 
 [project.urls]


### PR DESCRIPTION
Python 3.10 moves out of security updates at the end of summer.
