### PR TITLE
Add multilingual README support for zh-CN, ja, es

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # UFL - Unified Form Language
 
+<!-- hy-mt2-i18n:start -->
+**English** · [中文](./README_zh-CN.md) · [日本語](./README_ja.md) · [Español](./README_es.md)
+<!-- hy-mt2-i18n:end -->
+
 [![UFL CI](https://github.com/FEniCS/ufl/actions/workflows/all.yml/badge.svg)](https://github.com/FEniCS/ufl/actions/workflows/all.yml)
 [![Spack build](https://github.com/FEniCS/ufl/actions/workflows/spack.yml/badge.svg)](https://github.com/FEniCS/ufl/actions/workflows/spack.yml)
 [![Coverage Status](https://coveralls.io/repos/github/FEniCS/ufl/badge.svg?branch=main)](https://coveralls.io/github/FEniCS/ufl?branch=main)
@@ -31,4 +35,3 @@ GNU Lesser General Public License for more details.
 
 You should have received a copy of the GNU Lesser General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
-

--- a/README_es.md
+++ b/README_es.md
@@ -1,0 +1,35 @@
+# UFL - Lenguaje de Formas Unificado
+
+<!-- hy-mt2-i18n:start -->
+[English](./README.md) | [中文](./README_zh-CN.md) | [日本語](./README_ja.md) | **Español**
+<!-- hy-mt2-i18n:end -->
+
+
+[![UFL CI](https://github.com/FEniCS/ufl/actions/workflows/all.yml/badge.svg)](https://github.com/FEniCS/ufl/actions/workflows/all.yml)
+[![Construcción con Spack](https://github.com/FEniCS/ufl/actions/workflows/spack.yml/badge.svg)](https://github.com/FEniCS/ufl/actions/workflows/spack.yml)
+[![Estado de cobertura](https://coveralls.io/repos/github/FEniCS/ufl/badge.svg?branch=main)](https://coveralls.io/github/FEniCS/ufl?branch=main)
+
+El Lenguaje de Formas Unificado (UFL) es un lenguaje específico para un dominio
+destinado a la declaración de discretizaciones por elementos finitos de formas variacionales. Más precisamente, define una interfaz flexible para elegir espacios de elementos finitos y definir expresiones para formas débiles en una notación cercana a la notación matemática.
+
+UFL forma parte del Proyecto FEniCS. Para obtener más información, visite
+https://www.fenicsproject.org
+
+## Documentación
+
+La documentación se puede consultar en https://docs.fenicsproject.org
+
+## Licencia
+
+Este programa es software libre: puede redistribuirlo y/o modificarlo
+bajo los términos de la Licencia Pública General Menor de GNU, publicada por
+la Free Software Foundation, ya sea la versión 3 de dicha licencia o
+(cualquiera que usted elija) cualquier versión posterior.
+
+Este programa se distribuye con la esperanza de que sea útil,
+PERO SIN NINGUNA GARANTÍA; ni siquiera la garantía implícita de
+COMERCIALIZACIÓN o ADECUACIÓN PARA UN PROPÓSITO ESPECÍFICO. Consulte la
+Licencia Pública General Menor de GNU para obtener más detalles.
+
+Debe haber recibido una copia de la Licencia Pública General Menor de GNU
+junto con este programa. Si no es así, consulte <https://www.gnu.org/licenses/>.

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,0 +1,30 @@
+# データ入力
+
+<!-- hy-mt2-i18n:start -->
+[English](./README.md) | [中文](./README_zh-CN.md) | **日本語** | [Español](./README_es.md)
+<!-- hy-mt2-i18n:end -->
+
+ソースファイル：README.md
+
+Markdownコンテンツ：
+# UFL - Unified Form Language
+
+[![UFL CI](https://github.com/FEniCS/ufl/actions/workflows/all.yml/badge.svg)](https://github.com/FEniCS/ufl/actions/workflows/all.yml)
+[![Spack build](https://github.com/FEniCS/ufl/actions/workflows/spack.yml/badge.svg)](https://github.com/FEniCS/ufl/actions/workflows/spack.yml)
+[![Coverage Status](https://coveralls.io/repos/github/FEniCS/ufl/badge.svg?branch=main)](https://coveralls.io/github/FEniCS/ufl?branch=main)
+
+Unified Form Language（UFL）とは、変分形式の有限要素離散化を記述するためのドメイン特化型言語です。より正確に言うと、数学的表記に近い記法を用いて有限要素空間を選択したり、弱形式の式を定義したりするための柔軟なインターフェースを提供します。
+
+UFLはFEniCSプロジェクトの一部です。詳細については、https://www.fenicsproject.orgをご覧ください。
+
+## ドキュメント
+
+ドキュメントはhttps://docs.fenicsproject.orgで閲覧できます。
+
+## ライセンス
+
+このプログラムはフリーソフトウェアです。Free Software Foundationが公開しているGNU Lesser General Public Licenseの条件に従って、再配布または改変することができます。Licenseのバージョン3、または（お客様の選択により）それ以降のバージョンが適用されます。
+
+このプログラムは有用であることを願って配布されていますが、いかなる保証も一切ありません。商業性や特定の目的への適合性といった暗黙の保証さえも含まれません。詳細についてはGNU Lesser General Public Licenseをご覧ください。
+
+このプログラムと一緒にGNU Lesser General Public Licenseのコピーが同梱されているはずです。もし同梱されていない場合は、<https://www.gnu.org/licenses/>をご覧ください。

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -1,0 +1,26 @@
+# UFL - 统一形式语言
+
+<!-- hy-mt2-i18n:start -->
+[English](./README.md) | **中文** | [日本語](./README_ja.md) | [Español](./README_es.md)
+<!-- hy-mt2-i18n:end -->
+
+
+[![UFL CI状态](https://github.com/FEniCS/ufl/actions/workflows/all.yml/badge.svg)](https://github.com/FEniCS/ufl/actions/workflows/all.yml)
+[![Spack构建状态](https://github.com/FEniCS/ufl/actions/workflows/spack.yml/badge.svg)](https://github.com/FEniCS/ufl/actions/workflows/spack.yml)
+[![代码覆盖率状态](https://coveralls.io/repos/github/FEniCS/ufl/badge.svg?branch=main)](https://coveralls.io/github/FEniCS/ufl?branch=main)
+
+统一形式语言（UFL）是一种用于声明变分形式有限元离散化的领域专用语言。更准确地说，它提供了一种灵活的接口，允许用户选择有限元空间，并以接近数学符号的表示法来定义弱形式表达式。
+
+UFL是FEniCS项目的一部分。如需更多信息，请访问https://www.fenicsproject.org
+
+## 文档
+
+文档可在https://docs.fenicsproject.org查看
+
+## 许可证
+
+本程序属于自由软件：您可以根据自由软件基金会发布的GNU宽松通用公共许可证的条款来重新分发和/或修改它，即该许可证的第3版，或者（由您选择）任何更高版本的许可证。
+
+分发本程序是希望它能发挥作用，但**不提供任何担保**；甚至不包含关于适销性或适用于特定用途的隐含担保。详情请参阅GNU宽松通用公共许可证。
+
+您应该已经随本程序一同收到了GNU宽松通用公共许可证的副本。如果没有，请访问<https://www.gnu.org/licenses/>。


### PR DESCRIPTION
## What this PR does

Adds README support for Simplified Chinese, Japanese, and Spanish so readers of those languages
can follow your project just as easily.

This is additive and opt-in: no existing content or code is changed, and the
new files are safe to close or delete at any time.

## Why we opened this PR

We're the team behind [Tencent Hunyuan MT (HY MT2)](https://github.com/Tencent-Hunyuan/Hy-MT2),
a translation model we recently open-sourced. We're using it to help open
source projects we appreciate reach readers in more languages.

We'd also love your feedback — both on the new READMEs in this PR and on the
[model](https://github.com/Tencent-Hunyuan/Hy-MT2#contact-us) itself.

## Scope of changes

**New README files (with language-switcher links)**

- README_zh-CN.md
- README_ja.md
- README_es.md

**Existing READMEs updated with language-switcher links only**

- README.md

That's the entire change: 4 files. Nothing else is touched.

> Worried about the upkeep? A separate companion PR can help keep these
> translations in sync automatically going forward — adopt it only if you
> want to.