### PR TITLE
Fix generic terminal traversal for BaseForm types in extract_domains

### DIFF
--- a/test/test_domains.py
+++ b/test/test_domains.py
@@ -12,6 +12,7 @@ from ufl import (
     Cofunction,
     Constant,
     FunctionSpace,
+    Matrix,
     Mesh,
     TestFunction,
     TrialFunction,
@@ -26,9 +27,10 @@ from ufl import (
     tetrahedron,
     triangle,
 )
-from ufl.algorithms import compute_form_data
+from ufl.action import Action
+from ufl.algorithms import compute_form_data, extract_arguments, extract_coefficients
 from ufl.domain import extract_domains
-from ufl.form import ZeroBaseForm
+from ufl.form import FormSum, ZeroBaseForm
 from ufl.pullback import (
     IdentityPullback,  # noqa: F401
     identity_pullback,
@@ -430,3 +432,30 @@ def test_extract_domains_base_form():
     L = Cofunction(V.dual())
     residual = action(a, Coefficient(V)) - L
     assert extract_domains(residual) == (domain,)
+
+
+def test_extract_domains_nested_base_form():
+    # Nested BaseForm composition, e.g. Action(Action(Matrix, Coefficient),
+    # Coefficient) reached through a FormSum, exercises recursion through
+    # iter_expressions rather than a single level of unwrapping.
+    cell = triangle
+    domain = Mesh(LagrangeElement(cell, 1, (2,)))
+    element = FiniteElement("Lagrange", cell, 1, (), identity_pullback, H1)
+    V = FunctionSpace(domain, element)
+
+    A = Matrix(V, V)
+    f = Coefficient(V)
+    g = Coefficient(V)
+    h = Coefficient(V)
+
+    outer_action = action(action(A, f), g)
+    assert isinstance(outer_action, Action)
+    assert isinstance(outer_action.left(), Action)
+
+    outer_action2 = action(action(A, h), f)
+
+    fs = FormSum((outer_action, 1.0), (outer_action2, -1.0))
+
+    assert extract_domains(fs) == (domain,)
+    assert extract_arguments(fs) == []
+    assert set(extract_coefficients(fs)) == {f, g, h}

--- a/ufl/domain.py
+++ b/ufl/domain.py
@@ -420,7 +420,9 @@ def extract_domains(
         )
         return sort_domains(join_domains(domainlist, expand_mesh_sequence=expand_mesh_sequence))
     elif isinstance(expr, BaseForm) and not isinstance(expr, Expr):
-        return tuple(expr.ufl_domains())
+        return sort_domains(
+            join_domains(expr.ufl_domains(), expand_mesh_sequence=expand_mesh_sequence)
+        )
     else:
         domainlist = []
         for t in traverse_unique_terminals(expr):

--- a/ufl/domain.py
+++ b/ufl/domain.py
@@ -403,8 +403,8 @@ def extract_domains(
         `tuple` of domains.
 
     """
-    from ufl.core.expr import Expr
-    from ufl.form import BaseForm, Form
+    from ufl.algorithms.traversal import iter_expressions
+    from ufl.form import Form
     from ufl.integral import Integral
 
     if isinstance(expr, Form):
@@ -419,14 +419,21 @@ def extract_domains(
             extract_domains(expr.integrand(), expand_mesh_sequence=expand_mesh_sequence)
         )
         return sort_domains(join_domains(domainlist, expand_mesh_sequence=expand_mesh_sequence))
-    elif isinstance(expr, BaseForm) and not isinstance(expr, Expr):
-        return sort_domains(
-            join_domains(expr.ufl_domains(), expand_mesh_sequence=expand_mesh_sequence)
-        )
     else:
+        # iter_expressions decomposes FormSum/Action/Adjoint (and nested
+        # Forms within them) down to plain Expr trees and leaf BaseForms
+        # (e.g. ZeroBaseForm, Matrix), each of which traverse_unique_terminals
+        # can walk directly. Fall back to the bare expr for anything it
+        # doesn't recognise (e.g. a FunctionSpace), matching the
+        # AttributeError that as_domain() relies on to catch that case.
+        try:
+            exprs = iter_expressions(expr)
+        except ValueError:
+            exprs = (expr,)
         domainlist = []
-        for t in traverse_unique_terminals(expr):
-            domainlist.extend(t.ufl_domains())
+        for e in exprs:
+            for t in traverse_unique_terminals(e):
+                domainlist.extend(t.ufl_domains())
         return sort_domains(join_domains(domainlist, expand_mesh_sequence=expand_mesh_sequence))
 
 

--- a/ufl/form.py
+++ b/ufl/form.py
@@ -873,6 +873,12 @@ class ZeroBaseForm(BaseForm):
     used for sake of simplifying base-form expressions.
     """
 
+    # Not an Expr, so this doesn't come from the ufl_type() decorator.
+    # ufl_operands are the placeholder Arguments, which are themselves
+    # real terminals, so generic traversal (e.g. traverse_unique_terminals)
+    # should descend into them rather than stop here.
+    _ufl_is_terminal_ = False
+
     __slots__ = (
         "_arguments",
         "_coefficients",

--- a/ufl/matrix.py
+++ b/ufl/matrix.py
@@ -20,6 +20,12 @@ from ufl.utils.counted import Counted
 class Matrix(BaseForm, Counted):
     """An assemble linear operator between two function spaces."""
 
+    # Not an Expr, so this doesn't come from the ufl_type() decorator. A
+    # Matrix has no ufl_operands to descend into: it's a leaf whose domains
+    # and arguments are derived from its function spaces, so generic
+    # traversal (e.g. traverse_unique_terminals) should stop here.
+    _ufl_is_terminal_ = True
+
     __slots__ = (
         "_arguments",
         "_coefficients",
@@ -76,6 +82,12 @@ class Matrix(BaseForm, Counted):
 
         # Collect unique domains
         self._domains = join_domains([fs.ufl_domain() for fs in self._ufl_function_spaces])
+
+    def ufl_domains(self):
+        """Return all domains found in the base form."""
+        if self._domains is None:
+            self._analyze_domains()
+        return self._domains
 
     def __str__(self):
         """Format as a string."""


### PR DESCRIPTION
## Summary
- `extract_domains` only special-cased `Form` and `Integral`; anything else fell through to `traverse_unique_terminals`, which raised `AttributeError` on a bare `BaseForm` that isn't also an `Expr` (`ZeroBaseForm`, `FormSum`, `Action`, `Adjoint`, `Matrix`) since `ufl_type()` only assigns `_ufl_is_terminal_` to `Expr` subclasses. A prior fix routed those types through `isinstance(expr, BaseForm) and not isinstance(expr, Expr): return expr.ufl_domains()`, bypassing `join_domains`/`sort_domains` and so returning a raw `MeshSequence` on a mixed dual space instead of its component meshes — `extract_domains(cofunction)` disagreed with `extract_domains(form)` on the same space, and Firedrake's adjoint tape crashed taping a `solve()` with such a `Cofunction` RHS (`AttributeError: 'MeshSequenceGeometry' object has no attribute 'block_variable'`).
- Root cause instead of patch: give `ZeroBaseForm` (`_ufl_is_terminal_ = False`, since its operands are the placeholder `Argument`s, real terminals worth descending into) and `Matrix` (`_ufl_is_terminal_ = True`, a genuine leaf: its `ufl_operands` is `()`, its arguments/domains are synthesized from its function spaces rather than stored as operands) the trait `ufl_type()` never set for them. `Matrix` was also missing a `ufl_domains()` method entirely.
- With those two fixed, `extract_domains`'s generic branch no longer needs its own special case: it now routes through `iter_expressions`, the same unwrapping `algorithms/analysis.py`'s `extract_type` already uses to decompose `FormSum`/`Action`/`Adjoint` (and any `Form`s nested within them) down to plain `Expr` trees and leaf `BaseForm`s, each of which `traverse_unique_terminals` can walk directly — and which does respect `expand_mesh_sequence` uniformly. Falls back to the bare `expr` on `iter_expressions`' `ValueError` so `as_domain()`'s existing `AttributeError`-catching fallback for non-UFL inputs (e.g. a bare `FunctionSpace`) still works.
- Added a regression test for *nested* composition (`Action(Action(Matrix, Coefficient), Coefficient)` inside a `FormSum`), since the recursion through `iter_expressions` needs to handle more than one level of unwrapping and the existing single-level test didn't exercise that path.

## Test plan
- [x] `test/test_domains.py` and `test/test_duals.py` pass
- [x] Full UFL test suite (`pytest test/`) passes: 973 passed
- [x] Firedrake regression test `tests/firedrake/regression/test_adjoint_operators.py::test_cofunction_subfunctions_with_adjoint` passes
- [x] Manually verified `extract_domains` on a bare `ZeroBaseForm`, `Matrix`, `Adjoint`, `Action`, and a `FormSum` residual (`action(form, coeff) - cofunction`) all resolve the correct domain
- [x] New `test_extract_domains_nested_base_form` covers two-level-deep `Action(Action(...))` nesting; confirmed it fails with `AttributeError` if `Matrix`'s `_ufl_is_terminal_` trait is reverted, and that the pre-existing single-level test does not catch that regression on its own
