### PR TITLE
Add a signature to ZeroBaseForm

### DIFF
--- a/test/test_duals.py
+++ b/test/test_duals.py
@@ -188,6 +188,22 @@ def test_zero_base_form_list_arguments():
     assert hash(f) == hash(ZeroBaseForm((v,)))
 
 
+def test_zero_base_form_signature():
+    domain_2d = Mesh(LagrangeElement(triangle, 1, (2,)))
+    f_2d = LagrangeElement(triangle, 1)
+    V = FunctionSpace(domain_2d, f_2d)
+
+    v = TestFunction(V)
+    f = ZeroBaseForm((v,))
+
+    assert f.signature() == ZeroBaseForm((v,)).signature()
+    assert isinstance(f.signature(), str)
+
+    W = FunctionSpace(domain_2d, LagrangeElement(triangle, 2))
+    w = TestFunction(W)
+    assert f.signature() != ZeroBaseForm((w,)).signature()
+
+
 def test_zero_base_form_reconstruct():
     # ZeroBaseForm._ufl_expr_reconstruct_ inherited BaseForm's default,
     # `type(self)(*operands)`, which unpacks `ufl_operands` into positional

--- a/ufl/form.py
+++ b/ufl/form.py
@@ -933,12 +933,9 @@ class ZeroBaseForm(BaseForm):
     def signature(self):
         """Return a signature for use with JIT caches."""
         if self._signature is None:
-            renumbering = {
-                domain: i for i, domain in enumerate(self.ufl_domains())
-            }
+            renumbering = {domain: i for i, domain in enumerate(self.ufl_domains())}
             data = tuple(
-                argument._ufl_signature_data_(renumbering)
-                for argument in self.arguments()
+                argument._ufl_signature_data_(renumbering) for argument in self.arguments()
             )
             self._signature = hashlib.sha512(str(data).encode("utf-8")).hexdigest()
         return self._signature

--- a/ufl/form.py
+++ b/ufl/form.py
@@ -11,6 +11,7 @@
 # Modified by Nacime Bouziani, 2020.
 # Modified by Jørgen S. Dokken 2023.
 
+import hashlib
 import numbers
 import typing
 import warnings
@@ -884,6 +885,7 @@ class ZeroBaseForm(BaseForm):
         "_coefficients",
         "_domains",
         "_hash",
+        "_signature",
         # Pyadjoint compatibility
         "form",
         "ufl_operands",
@@ -896,6 +898,7 @@ class ZeroBaseForm(BaseForm):
         self._arguments = arguments
         self.ufl_operands = arguments
         self._hash = None
+        self._signature = None
         self._domains = None
         self.form = None
 
@@ -926,6 +929,19 @@ class ZeroBaseForm(BaseForm):
     def empty(self):
         """Returns whether the ZeroBaseForm has no components, which is always true."""
         return True
+
+    def signature(self):
+        """Return a signature for use with JIT caches."""
+        if self._signature is None:
+            renumbering = {
+                domain: i for i, domain in enumerate(self.ufl_domains())
+            }
+            data = tuple(
+                argument._ufl_signature_data_(renumbering)
+                for argument in self.arguments()
+            )
+            self._signature = hashlib.sha512(str(data).encode("utf-8")).hexdigest()
+        return self._signature
 
     def __ne__(self, other):
         """Overwrite BaseForm.__neq__ which relies on `equals`."""


### PR DESCRIPTION
## Summary

- Add a stable, cached signature for `ZeroBaseForm`.
- Include argument and domain signature data so zero forms on different spaces do not collide.
- Add regression coverage for equivalent and distinct zero forms.

## Testing

- `python -m pytest -q`
- 1025 passed